### PR TITLE
fix: update CI workflows for CLI app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +35,7 @@ jobs:
         run: pnpm lint
 
   test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
@@ -57,10 +59,6 @@ jobs:
         run: pnpm test:cov
         env:
           NODE_ENV: test
-          API_PORT: 3000
-          API_SECRET_KEY: test-secret-key-for-e2e-tests-minimum
-          DB_DRIVER: sqlite
-          DB_SQLITE_PATH: config/db/db.sqlite3
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
@@ -68,6 +66,7 @@ jobs:
           files: ./coverage/lcov.info
 
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
@@ -91,6 +90,7 @@ jobs:
         run: pnpm build
 
   e2e:
+    name: E2E
     runs-on: ubuntu-latest
 
     steps:
@@ -114,7 +114,3 @@ jobs:
         run: pnpm test:e2e
         env:
           NODE_ENV: test
-          API_PORT: 3000
-          API_SECRET_KEY: test-secret-key-for-e2e-tests-minimum
-          DB_DRIVER: sqlite
-          DB_SQLITE_PATH: config/db/db.sqlite3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,8 @@ on:
       - 'v*'
 
 jobs:
-  build-and-push:
+  docker-image-build:
+    name: Docker Image Build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,12 +18,12 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  trivy-vuln-scan:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Build
+    name: Trivy Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
     "typescript": "^5.9.3",
     "yaml": "^2.8.2"
   },
+  "lint-staged": {
+    "*.{ts,js}": [
+      "biome check --write --no-errors-on-unmatched",
+      "biome format --write"
+    ]
+  },
   "pnpm": {
     "overrides": {
       "file-type": ">=21.3.2"


### PR DESCRIPTION
## Summary

- Add job names for better readability in GitHub Actions
- Remove unnecessary env vars from CI (API_PORT, API_SECRET_KEY, DB_*)
- Rename docker job to `docker-image-build`
- Rename trivy job to `trivy-vuln-scan`
- Add lint-staged config for Biome

## Changes

### CI Workflow
- Added `name` to all jobs: Lint, Test, Build, E2E
- Removed unnecessary environment variables for CLI app

### Docker Workflow  
- Renamed job from `build-and-push` to `docker-image-build`

### Trivy Workflow
- Renamed job from `build` to `trivy-vuln-scan`

### lint-staged
- Added configuration for Biome linter/formatter