### PR TITLE
test: add e2e coverage configuration and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lerna-debug.log*
 
 # Tests
 /coverage
+/coverage-e2e
 /.nyc_output
 
 # Swagger

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "test:watch": "jest --watch",
     "test:cov": "rimraf coverage && jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:cov": "rimraf coverage-e2e && jest --config ./test/jest-e2e.json --coverage",
+    "test:all:cov": "pnpm test:cov && pnpm test:e2e:cov",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "prepare": "husky"
   },

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -8,5 +8,10 @@
   },
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/../src/$1"
-  }
+  },
+  "collectCoverageFrom": [
+    "../src/**/*.ts",
+    "../src/**/*.js"
+  ],
+  "coverageDirectory": "../coverage-e2e"
 }


### PR DESCRIPTION
## Summary
Add e2e test coverage collection configuration and new npm scripts for running e2e tests with coverage.

## Changes
- Updated `test/jest-e2e.json` to collect coverage from `src/` directory
- Added `test:e2e:cov` script for e2e tests with coverage
- Added `test:all:cov` script to run both unit and e2e coverage
- Updated `.gitignore` to ignore `coverage-e2e/` directory

## New Scripts
- `pnpm test:e2e:cov` - Run e2e tests with coverage (outputs to `coverage-e2e/`)
- `pnpm test:all:cov` - Run both unit and e2e tests with coverage