### PR TITLE
fix: use relative paths for symlinks in sync-agents script

### DIFF
--- a/config/scripts/sync-agents.mjs
+++ b/config/scripts/sync-agents.mjs
@@ -295,7 +295,8 @@ function createSymlink(source, target) {
   }
 
   const symlinkType = getSymlinkType(sourcePath)
-  fs.symlinkSync(sourcePath, targetPath, symlinkType)
+  const relativeSource = path.relative(targetDir, sourcePath)
+  fs.symlinkSync(relativeSource, targetPath, symlinkType)
 }
 
 function createSymlinksForTool(toolKey) {


### PR DESCRIPTION
## Summary
Fix the sync-agents script to generate relative path symlinks instead of absolute paths.

## Problem
The `createSymlink` function was creating absolute path symlinks, which break when cloned on different machines.

## Solution
Calculate the relative path from the target directory to the source before creating the symlink.

## Before vs After

| File | Before | After |
|------|--------|-------|
| AGENTS.md | Absolute path | `.paw-tools/main.md` |
| .opencode/skills | Absolute path | `../.paw-tools/skills` |
| .opencode/agents | Absolute path | `../.paw-tools/agents` |

## Verification
```bash
ls -la AGENTS.md
# Shows: AGENTS.md -> .paw-tools/main.md ✅
```