### PR TITLE
fix: init-project command improvements

### DIFF
--- a/src/cli/commands/init-project.command.spec.ts
+++ b/src/cli/commands/init-project.command.spec.ts
@@ -501,10 +501,11 @@ describe('InitProjectCommand', () => {
     })
 
     it('should use calver format when selected', async () => {
+      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
       ;(clack.text as jest.Mock)
         .mockResolvedValueOnce('test-name')
         .mockResolvedValueOnce('test-desc')
-        .mockResolvedValueOnce('2024.03.1')
+        .mockResolvedValueOnce(todayCalver)
         .mockResolvedValueOnce('test-author')
       ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
       ;(clack.confirm as jest.Mock).mockResolvedValue(true)
@@ -513,7 +514,7 @@ describe('InitProjectCommand', () => {
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
       expect(clack.select).toHaveBeenCalled()
-      expect(consoleSpy).toHaveBeenCalledWith('  version: "0.1.0" → "2024.03.1"')
+      expect(consoleSpy).toHaveBeenCalledWith(`  version: "0.1.0" → "${todayCalver}"`)
     })
 
     it('should update both package.json and docker-compose.yml when docker exists', async () => {
@@ -1060,8 +1061,9 @@ describe('InitProjectCommand', () => {
     })
 
     it('should return calver placeholder', () => {
+      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
       expect((command as Testable<InitProjectCommand>)['getVersionPlaceholder']('calver')).toBe(
-        '2024.03.1'
+        todayCalver
       )
     })
 
@@ -1084,8 +1086,9 @@ describe('InitProjectCommand', () => {
     })
 
     it('should return calver default with current date', () => {
+      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
       const result = (command as Testable<InitProjectCommand>)['getVersionDefault']('calver')
-      expect(result).toMatch(/^\d{4}\.\d{2}\.0$/)
+      expect(result).toBe(todayCalver)
     })
 
     it('should return custom default', () => {
@@ -1164,6 +1167,18 @@ describe('InitProjectCommand', () => {
       expect(
         (command as Testable<InitProjectCommand>)['validateVersion']('release-1.0', 'custom')
       ).toBeUndefined()
+    })
+  })
+
+  describe('getTodayCalver', () => {
+    it('should return today in YYYY.MM.DD format', () => {
+      const result = (command as Testable<InitProjectCommand>)['getTodayCalver']()
+      expect(result).toMatch(/^\d{4}\.\d{2}\.\d{2}$/)
+      const [year, month, day] = result.split('.').map(Number)
+      const today = new Date()
+      expect(year).toBe(today.getFullYear())
+      expect(month).toBe(today.getMonth() + 1)
+      expect(day).toBe(today.getDate())
     })
   })
 

--- a/src/cli/commands/init-project.command.ts
+++ b/src/cli/commands/init-project.command.ts
@@ -48,7 +48,7 @@ export class InitProjectCommand extends CommandRunner {
       case 'semver':
         return '0.1.0'
       case 'calver':
-        return '2024.03.1'
+        return this.getTodayCalver()
       case 'custom':
         return 'v1'
       default:
@@ -60,15 +60,18 @@ export class InitProjectCommand extends CommandRunner {
     switch (format) {
       case 'semver':
         return '0.1.0'
-      case 'calver': {
-        const now = new Date()
-        return `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.0`
-      }
+      case 'calver':
+        return this.getTodayCalver()
       case 'custom':
         return '1'
       default:
         return '0.1.0'
     }
+  }
+
+  private getTodayCalver(): string {
+    const now = new Date()
+    return `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')}`
   }
 
   private validateVersion(value: string, format: string): string | undefined {


### PR DESCRIPTION
## Summary
- Remove spinner from instant file operations (not visible for fast operations)
- Show which files were updated in interactive mode
- Fix calver format to use full date (YYYY.MM.DD) instead of hardcoded values
- Add `getTodayCalver()` helper function for DRY date formatting

## Changes
- `init-project.command.ts`: Replace spinner with console.log, add file update output
- `init-project.command.ts`: Add `getTodayCalver()` for consistent date formatting
- `init-project.command.spec.ts`: Update tests for new behavior

## Testing
- All 115 tests passing
- Build passing
- Lint passing