### PR TITLE
feat: add PromptService and validation utilities

### DIFF
--- a/.paw-tools/main.md
+++ b/.paw-tools/main.md
@@ -407,3 +407,111 @@ const author = `${nameResult.stdout} <${emailResult.stdout}>`
 - Use path alias `@/` for internal imports (mapped to `src/`)
 - Environment variables validated with Joi schema
 - Secrets should never be logged or committed
+
+## PromptModule
+
+All CLI prompts MUST use `PromptService`. Never use `@clack/prompts` directly in commands. The service handles cancel detection and provides a consistent user experience.
+
+### Location
+
+```
+src/shared/prompt/
+├── interfaces/
+│   ├── text-prompter.interface.ts
+│   ├── select-prompter.interface.ts
+│   ├── confirm-prompter.interface.ts
+│   ├── spinner-prompter.interface.ts
+│   └── index.ts
+├── prompt.service.ts
+├── prompt.module.ts
+└── index.ts
+```
+
+### Usage
+
+```typescript
+import { PromptService } from '@/shared/prompt'
+
+export class MyCommand extends CommandRunner {
+  private readonly promptService: PromptService
+
+  constructor() {
+    super()
+    this.promptService = new PromptService()
+  }
+
+  async run() {
+    const name = await this.promptService.text({
+      message: 'Enter project name:',
+      placeholder: 'my-project'
+    })
+
+    const type = await this.promptService.select({
+      message: 'Select type:',
+      options: [
+        { value: 'api', label: 'API' },
+        { value: 'web', label: 'Web' }
+      ]
+    })
+
+    const confirm = await this.promptService.confirm({
+      message: 'Continue?'
+    })
+  }
+}
+```
+
+### Available Methods
+
+| Method | Description |
+|--------|-------------|
+| `text(options)` | Prompt for text input with optional validation |
+| `select(options)` | Prompt for single selection from options |
+| `confirm(options)` | Prompt for yes/no confirmation |
+| `spinner(options, fn)` | Run async function with spinner (auto handles Done/Failed) |
+| `spinnerMessage(options)` | Get spinner with manual start/stop control |
+
+### Cancel Handling
+
+All prompts automatically handle user cancellation (Ctrl+C). When cancelled:
+1. Displays "Operation cancelled."
+2. Exits process with code 0
+
+**Do NOT use `@clack/prompts` directly in commands.**
+
+## Validation Utilities
+
+Shared validation functions for common patterns. Located in `src/shared/utils.helper.ts`.
+
+### Available Functions
+
+| Function | Description |
+|----------|-------------|
+| `validateKebabCase(value)` | Validates kebab-case (lowercase, numbers, hyphens) |
+| `validateSemver(value)` | Validates semver format (x.y.z) |
+| `validateCalver(value)` | Validates calver format (YYYY.M.PATCH) |
+| `getCalver(date?)` | Returns date in YYYY.MM.DD format (defaults to today) |
+| `isEmptyObject(obj)` | Checks if object is empty |
+
+### Usage
+
+```typescript
+import { validateKebabCase, validateSemver, validateCalver, getCalver } from '@/shared/utils.helper'
+
+// Validation returns error message or undefined if valid
+const nameError = validateKebabCase('My Project')
+if (nameError) {
+  console.error(nameError) // "Name must be kebab-case (lowercase, numbers, hyphens)"
+}
+
+const semverError = validateSemver('1.0')
+if (semverError) {
+  console.error(semverError) // "Must be semver format (x.y.z)"
+}
+
+// Get current date in calver format
+const today = getCalver() // "2026.03.24"
+
+// Or for a specific date
+const specific = getCalver(new Date('2024-01-15')) // "2024.01.15"
+```

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,6 +5,7 @@ export default {
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
+  transformIgnorePatterns: ['node_modules/(?!(@clack|sisteransi)/)'],
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',

--- a/src/__mocks__/@clack/prompts.ts
+++ b/src/__mocks__/@clack/prompts.ts
@@ -1,0 +1,9 @@
+export const text = jest.fn()
+export const confirm = jest.fn()
+export const select = jest.fn()
+export const spinner = jest.fn(() => ({
+  start: jest.fn(),
+  stop: jest.fn()
+}))
+export const cancel = jest.fn()
+export const isCancel = jest.fn(() => false)

--- a/src/cli/commands/init-project.command.spec.ts
+++ b/src/cli/commands/init-project.command.spec.ts
@@ -1,7 +1,5 @@
 // biome-ignore-all lint/complexity/useLiteralKeys: bracket notation required for private access
 
-import * as clack from '@clack/prompts'
-
 import type { Testable } from '@/typings/tests'
 
 import { InitProjectCommand } from './init-project.command'
@@ -14,21 +12,21 @@ const mockFileHandler = {
   writeJson: jest.fn().mockResolvedValue(undefined)
 }
 
+const mockPromptService = {
+  text: jest.fn(),
+  select: jest.fn(),
+  confirm: jest.fn(),
+  spinner: jest.fn(),
+  spinnerMessage: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() }))
+}
+
 jest.mock('node:fs')
 jest.mock('node:fs/promises')
 jest.mock('@/shared/file-handler', () => ({
   FileHandlerService: jest.fn().mockImplementation(() => mockFileHandler)
 }))
-jest.mock('@clack/prompts', () => ({
-  text: jest.fn(),
-  confirm: jest.fn(),
-  select: jest.fn(),
-  spinner: jest.fn(() => ({
-    start: jest.fn(),
-    stop: jest.fn()
-  })),
-  cancel: jest.fn(),
-  isCancel: jest.fn(() => false)
+jest.mock('@/shared/prompt', () => ({
+  PromptService: jest.fn().mockImplementation(() => mockPromptService)
 }))
 
 jest.mock('yaml', () => {
@@ -197,18 +195,12 @@ describe('InitProjectCommand', () => {
   let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
-    // Reset mocks completely and re-apply defaults
-    ;(clack.text as jest.Mock).mockReset()
-    ;(clack.confirm as jest.Mock).mockReset()
-    ;(clack.select as jest.Mock).mockReset()
-    ;(clack.spinner as jest.Mock).mockReset()
-    ;(clack.cancel as jest.Mock).mockReset()
-    ;(clack.isCancel as unknown as jest.Mock).mockReset()
-    ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
-    ;(clack.spinner as jest.Mock).mockImplementation(() => ({
-      start: jest.fn(),
-      stop: jest.fn()
-    }))
+    mockPromptService.text.mockReset()
+    mockPromptService.select.mockReset()
+    mockPromptService.confirm.mockReset()
+    mockPromptService.spinner.mockReset()
+    mockPromptService.spinnerMessage.mockReset()
+    mockPromptService.spinnerMessage.mockReturnValue({ start: jest.fn(), stop: jest.fn() })
     mockFileHandler.exists.mockReset()
     mockFileHandler.readFile.mockReset()
     mockFileHandler.readJson.mockReset()
@@ -216,7 +208,6 @@ describe('InitProjectCommand', () => {
     mockFileHandler.writeJson.mockReset()
     mockProcessService.exec.mockReset()
     mockProcessService.exec.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 })
-    // Set default behaviors
     mockFileHandler.exists.mockReturnValue(true)
     mockFileHandler.readFile.mockResolvedValue('{}')
     mockFileHandler.readJson.mockResolvedValue({})
@@ -261,7 +252,7 @@ describe('InitProjectCommand', () => {
   describe('initializeWithDefaults', () => {
     it('should use spinner and default values', async () => {
       const mockSpinner = { start: jest.fn(), stop: jest.fn() }
-      ;(clack.spinner as jest.Mock).mockReturnValue(mockSpinner)
+      mockPromptService.spinnerMessage.mockReturnValue(mockSpinner)
       mockFileHandler.exists.mockReturnValue(true)
       mockFileHandler.readJson.mockResolvedValue({
         name: 'old',
@@ -278,7 +269,7 @@ describe('InitProjectCommand', () => {
 
     it('should skip package.json update if file does not exist', async () => {
       const mockSpinner = { start: jest.fn(), stop: jest.fn() }
-      ;(clack.spinner as jest.Mock).mockReturnValue(mockSpinner)
+      mockPromptService.spinnerMessage.mockReturnValue(mockSpinner)
       mockFileHandler.exists.mockReturnValue(false)
 
       await (command as Testable<InitProjectCommand>)['initializeWithDefaults']()
@@ -297,9 +288,9 @@ describe('InitProjectCommand', () => {
     })
 
     it('should prompt for all fields using current config', async () => {
-      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
-      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.text as jest.Mock).mockResolvedValue('test-value')
+      ;(mockPromptService.select as jest.Mock).mockResolvedValue('pnpm')
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.readJson.mockResolvedValue({
         name: 'current-name',
         description: 'current-desc',
@@ -309,18 +300,18 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(clack.text).toHaveBeenCalledTimes(4)
-      expect(clack.confirm).toHaveBeenCalledTimes(1)
+      expect(mockPromptService.text).toHaveBeenCalledTimes(4)
+      expect(mockPromptService.confirm).toHaveBeenCalledTimes(1)
     })
 
     it('should show changes before confirmation', async () => {
-      ;(clack.text as jest.Mock)
+      ;(mockPromptService.text as jest.Mock)
         .mockResolvedValueOnce('new-name')
         .mockResolvedValueOnce('current-desc')
         .mockResolvedValueOnce('1.0.0')
         .mockResolvedValueOnce('current-author')
-      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.select as jest.Mock).mockResolvedValue('pnpm')
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.readJson.mockResolvedValue({
         name: 'current-name',
         description: 'current-desc',
@@ -334,154 +325,16 @@ describe('InitProjectCommand', () => {
       expect(consoleSpy).toHaveBeenCalledWith('  name: "current-name" → "new-name"')
     })
 
-    it('should cancel when user rejects confirmation', async () => {
-      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
-      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(false)
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation()
-
-      await (command as Testable<InitProjectCommand>)['initializeInteractive']()
-
-      expect(clack.cancel).toHaveBeenCalledWith('Operation cancelled.')
-      expect(_exitSpy).toHaveBeenCalledWith(0)
-    })
-
-    it('should cancel on user cancel for name', async () => {
-      ;(clack.text as jest.Mock).mockResolvedValue(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(true)
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-      expect(_exitSpy).toHaveBeenCalledWith(0)
-    })
-
-    it('should cancel on user cancel for description', async () => {
-      ;(clack.text as jest.Mock)
-        .mockResolvedValueOnce('test-name')
-        .mockResolvedValueOnce(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel on user cancel for version', async () => {
-      ;(clack.text as jest.Mock)
-        .mockResolvedValueOnce('test-name')
-        .mockResolvedValueOnce('test-desc')
-        .mockResolvedValueOnce(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      ;(clack.text as jest.Mock)
-        .mockResolvedValueOnce('test-name')
-        .mockResolvedValueOnce('test-desc')
-        .mockResolvedValueOnce('1.0.0')
-        .mockResolvedValueOnce(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      mockFileHandler.exists.mockImplementation((path: string) => {
-        return path.includes('package.json')
-      })
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel on user cancel for author', async () => {
-      ;(clack.text as jest.Mock)
-        .mockResolvedValueOnce('test-name')
-        .mockResolvedValueOnce('test-desc')
-        .mockResolvedValueOnce('1.0.0')
-        .mockResolvedValueOnce(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      mockFileHandler.exists.mockImplementation((path: string) => {
-        return path.includes('package.json')
-      })
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel when confirmation is cancelled', async () => {
-      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      mockFileHandler.exists.mockImplementation((path: string) => {
-        return path.includes('package.json')
-      })
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel on version format selection cancel', async () => {
-      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
-      ;(clack.select as jest.Mock).mockResolvedValue(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      mockFileHandler.exists.mockImplementation((path: string) => {
-        return path.includes('package.json')
-      })
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeInteractive']()
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
     it('should show no changes message when values are same', async () => {
       mockFileHandler.exists.mockImplementation((path: string) => {
         return !path.includes('docker-compose') // Skip docker-compose checks
       })
-      ;(clack.text as jest.Mock)
+      ;(mockPromptService.text as jest.Mock)
         .mockResolvedValueOnce('api') // name
         .mockResolvedValueOnce('current-value') // description
         .mockResolvedValueOnce('current-value') // version
         .mockResolvedValueOnce('Git Name <git@email.com>') // author
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.readJson.mockResolvedValue({
         name: 'api',
         description: 'current-value',
@@ -501,32 +354,35 @@ describe('InitProjectCommand', () => {
     })
 
     it('should use calver format when selected', async () => {
-      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
-      ;(clack.text as jest.Mock)
+      const { getCalver } = require('@/shared/utils.helper')
+      const todayCalver = getCalver()
+      ;(mockPromptService.text as jest.Mock)
         .mockResolvedValueOnce('test-name')
         .mockResolvedValueOnce('test-desc')
         .mockResolvedValueOnce(todayCalver)
         .mockResolvedValueOnce('test-author')
-      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.select as jest.Mock).mockResolvedValue('pnpm')
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.readJson.mockResolvedValue({})
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(clack.select).toHaveBeenCalled()
+      expect(mockPromptService.select).toHaveBeenCalled()
       expect(consoleSpy).toHaveBeenCalledWith(`  version: "0.1.0" → "${todayCalver}"`)
     })
 
     it('should update both package.json and docker-compose.yml when docker exists', async () => {
-      ;(clack.text as jest.Mock)
+      ;(mockPromptService.text as jest.Mock)
         .mockResolvedValueOnce('test-name')
         .mockResolvedValueOnce('test-desc')
         .mockResolvedValueOnce('1.0.0')
         .mockResolvedValueOnce('test-author')
         .mockResolvedValueOnce('test-service')
         .mockResolvedValueOnce('latest')
-      ;(clack.select as jest.Mock).mockResolvedValueOnce('semver').mockResolvedValueOnce('pnpm')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.select as jest.Mock)
+        .mockResolvedValueOnce('semver')
+        .mockResolvedValueOnce('pnpm')
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.exists.mockReturnValue(true) // docker-compose.yml exists
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
@@ -540,13 +396,13 @@ describe('InitProjectCommand', () => {
     })
 
     it('should accept valid kebab-case names', async () => {
-      ;(clack.text as jest.Mock)
+      ;(mockPromptService.text as jest.Mock)
         .mockResolvedValueOnce('my-awesome-app')
         .mockResolvedValueOnce('test-desc')
         .mockResolvedValueOnce('0.1.0')
         .mockResolvedValueOnce('test-author')
-      ;(clack.select as jest.Mock).mockResolvedValue('semver')
-      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(mockPromptService.select as jest.Mock).mockResolvedValue('semver')
+      ;(mockPromptService.confirm as jest.Mock).mockResolvedValue(true)
       mockFileHandler.exists.mockImplementation((path: string) => {
         return path.includes('package.json')
       })
@@ -588,8 +444,10 @@ describe('InitProjectCommand', () => {
 
     it('should prompt for Docker config when docker-compose.yml exists', async () => {
       mockFileHandler.exists.mockReturnValue(true)
-      ;(clack.text as jest.Mock).mockResolvedValueOnce('my-service').mockResolvedValueOnce('1.0.0')
-      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
+      ;(mockPromptService.text as jest.Mock)
+        .mockResolvedValueOnce('my-service')
+        .mockResolvedValueOnce('1.0.0')
+      ;(mockPromptService.select as jest.Mock).mockResolvedValue('pnpm')
 
       const result = await (command as Testable<InitProjectCommand>)['initializeDockerConfig'](
         'my-project'
@@ -602,58 +460,6 @@ describe('InitProjectCommand', () => {
         packageManager: 'pnpm',
         registryUrl: 'https://registry.npmjs.org/'
       })
-    })
-
-    it('should cancel on service name cancel', async () => {
-      mockFileHandler.exists.mockReturnValue(true)
-      ;(clack.text as jest.Mock).mockResolvedValue(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(true)
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeDockerConfig']('my-project')
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel on image version cancel', async () => {
-      mockFileHandler.exists.mockReturnValue(true)
-      ;(clack.text as jest.Mock)
-        .mockResolvedValueOnce('my-service')
-        .mockResolvedValueOnce(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeDockerConfig']('my-project')
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
-    })
-
-    it('should cancel on package manager cancel', async () => {
-      mockFileHandler.exists.mockReturnValue(true)
-      ;(clack.text as jest.Mock).mockResolvedValueOnce('my-service').mockResolvedValueOnce('1.0.0')
-      ;(clack.select as jest.Mock).mockResolvedValue(Symbol('cancel'))
-      ;(clack.isCancel as unknown as jest.Mock).mockImplementation(
-        (val: unknown) => typeof val === 'symbol'
-      )
-      const _exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
-        throw new Error('process.exit')
-      }) as (code?: number) => never)
-
-      await expect(
-        (command as Testable<InitProjectCommand>)['initializeDockerConfig']('my-project')
-      ).rejects.toThrow('process.exit')
-
-      expect(clack.cancel).toHaveBeenCalled()
     })
   })
 
@@ -1061,7 +867,8 @@ describe('InitProjectCommand', () => {
     })
 
     it('should return calver placeholder', () => {
-      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
+      const { getCalver } = require('@/shared/utils.helper')
+      const todayCalver = getCalver()
       expect((command as Testable<InitProjectCommand>)['getVersionPlaceholder']('calver')).toBe(
         todayCalver
       )
@@ -1086,7 +893,8 @@ describe('InitProjectCommand', () => {
     })
 
     it('should return calver default with current date', () => {
-      const todayCalver = (command as Testable<InitProjectCommand>)['getTodayCalver']()
+      const { getCalver } = require('@/shared/utils.helper')
+      const todayCalver = getCalver()
       const result = (command as Testable<InitProjectCommand>)['getVersionDefault']('calver')
       expect(result).toBe(todayCalver)
     })
@@ -1167,18 +975,6 @@ describe('InitProjectCommand', () => {
       expect(
         (command as Testable<InitProjectCommand>)['validateVersion']('release-1.0', 'custom')
       ).toBeUndefined()
-    })
-  })
-
-  describe('getTodayCalver', () => {
-    it('should return today in YYYY.MM.DD format', () => {
-      const result = (command as Testable<InitProjectCommand>)['getTodayCalver']()
-      expect(result).toMatch(/^\d{4}\.\d{2}\.\d{2}$/)
-      const [year, month, day] = result.split('.').map(Number)
-      const today = new Date()
-      expect(year).toBe(today.getFullYear())
-      expect(month).toBe(today.getMonth() + 1)
-      expect(day).toBe(today.getDate())
     })
   })
 

--- a/src/cli/commands/init-project.command.ts
+++ b/src/cli/commands/init-project.command.ts
@@ -2,12 +2,13 @@
 
 import { join } from 'node:path'
 
-import { cancel, confirm, isCancel, select, spinner, text } from '@clack/prompts'
 import { Command, CommandRunner, Option } from 'nest-commander'
 import { isMap, isPair, isScalar, type Pair, parseDocument, type Scalar, type YAMLMap } from 'yaml'
 
 import { FileHandlerService } from '@/shared/file-handler'
 import { ProcessService } from '@/shared/process'
+import { PromptService } from '@/shared/prompt'
+import { getCalver, validateCalver, validateKebabCase, validateSemver } from '@/shared/utils.helper'
 
 interface InitProjectOptions {
   defaults?: boolean
@@ -36,11 +37,13 @@ export class InitProjectCommand extends CommandRunner {
   private readonly mainServiceName = 'api'
   private readonly fileHandler: FileHandlerService
   private readonly processService: ProcessService
+  private readonly promptService: PromptService
 
   constructor() {
     super()
     this.fileHandler = new FileHandlerService()
     this.processService = new ProcessService()
+    this.promptService = new PromptService()
   }
 
   private getVersionPlaceholder(format: string): string {
@@ -48,7 +51,7 @@ export class InitProjectCommand extends CommandRunner {
       case 'semver':
         return '0.1.0'
       case 'calver':
-        return this.getTodayCalver()
+        return getCalver()
       case 'custom':
         return 'v1'
       default:
@@ -61,7 +64,7 @@ export class InitProjectCommand extends CommandRunner {
       case 'semver':
         return '0.1.0'
       case 'calver':
-        return this.getTodayCalver()
+        return getCalver()
       case 'custom':
         return '1'
       default:
@@ -69,25 +72,19 @@ export class InitProjectCommand extends CommandRunner {
     }
   }
 
-  private getTodayCalver(): string {
-    const now = new Date()
-    return `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, '0')}.${String(now.getDate()).padStart(2, '0')}`
-  }
-
   private validateVersion(value: string, format: string): string | undefined {
     if (!value || value.length === 0) return undefined
 
     switch (format) {
       case 'semver':
-        if (!/^\d+\.\d+\.\d+/.test(value)) return 'Must be semver format (x.y.z)'
-        break
+        return validateSemver(value)
       case 'calver':
-        if (!/^\d{4}\.\d{1,2}\.\d+/.test(value)) return 'Must be calver format (YYYY.M.PATCH)'
-        break
+        return validateCalver(value)
       case 'custom':
-        break
+        return undefined
+      default:
+        return undefined
     }
-    return undefined
   }
 
   private async getGitAuthor(): Promise<string> {
@@ -175,27 +172,19 @@ export class InitProjectCommand extends CommandRunner {
       return null
     }
 
-    const serviceName = await text({
+    const serviceName = await this.promptService.text({
       message: 'Enter Docker service name:',
       placeholder: projectName,
       defaultValue: projectName
     })
-    if (isCancel(serviceName)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const imageVersion = await text({
+    const imageVersion = await this.promptService.text({
       message: 'Enter Docker image version:',
       placeholder: 'latest',
       defaultValue: 'latest'
     })
-    if (isCancel(imageVersion)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const packageManager = await select({
+    const packageManager = await this.promptService.select({
       message: 'Select package manager:',
       options: [
         { value: 'pnpm', label: 'pnpm' },
@@ -203,18 +192,14 @@ export class InitProjectCommand extends CommandRunner {
         { value: 'yarn', label: 'yarn' }
       ]
     })
-    if (isCancel(packageManager)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
     const registryUrl = 'https://registry.npmjs.org/'
 
     return {
-      serviceName: serviceName as string,
+      serviceName,
       projectName,
-      imageVersion: imageVersion as string,
-      packageManager: packageManager as string,
+      imageVersion,
+      packageManager,
       registryUrl
     }
   }
@@ -305,8 +290,10 @@ export class InitProjectCommand extends CommandRunner {
   }
 
   private async initializeWithDefaults(): Promise<void> {
-    const s = spinner()
-    s.start('Initializing project with defaults...')
+    const s = this.promptService.spinnerMessage({
+      message: 'Initializing project with defaults...'
+    })
+    s.start()
 
     const config = await this.getDefaultConfig()
     await this.updatePackageJson(config)
@@ -334,74 +321,52 @@ export class InitProjectCommand extends CommandRunner {
   private async initializeInteractive(): Promise<void> {
     const currentConfig = await this.getCurrentConfig()
 
-    const name = await text({
+    const name = await this.promptService.text({
       message: 'Enter project name:',
       placeholder: currentConfig.name,
       defaultValue: currentConfig.name,
       validate: (value) => {
         if (!value || value.length === 0) return 'Name is required!'
-        if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(value)) {
-          return 'Name must be kebab-case (lowercase, numbers, hyphens)'
-        }
+        return validateKebabCase(value)
       }
     })
-    if (isCancel(name)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const description = await text({
+    const description = await this.promptService.text({
       message: 'Enter project description:',
       placeholder: currentConfig.description,
       defaultValue: currentConfig.description
     })
-    if (isCancel(description)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const versionFormat = await select({
+    const versionFormat = await this.promptService.select({
       message: 'Select version format:',
       options: [
         { value: 'semver', label: 'Semantic (0.1.0)' },
-        { value: 'calver', label: 'Calendar (2024.03.1)' },
+        { value: 'calver', label: `Calendar (${getCalver()})` },
         { value: 'custom', label: 'Custom (any format)' }
       ]
     })
-    if (isCancel(versionFormat)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const version = await text({
+    const version = await this.promptService.text({
       message: 'Enter project version:',
-      placeholder: this.getVersionPlaceholder(versionFormat as string),
-      defaultValue: this.getVersionDefault(versionFormat as string),
-      validate: (value) => this.validateVersion(value, versionFormat as string)
+      placeholder: this.getVersionPlaceholder(versionFormat),
+      defaultValue: this.getVersionDefault(versionFormat),
+      validate: (value) => this.validateVersion(value, versionFormat)
     })
-    if (isCancel(version)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
-    const author = await text({
+    const author = await this.promptService.text({
       message: 'Enter project author:',
       placeholder: currentConfig.author,
       defaultValue: currentConfig.author
     })
-    if (isCancel(author)) {
-      cancel('Operation cancelled.')
-      process.exit(0)
-    }
 
     const config: ProjectConfig = {
-      name: name as string,
-      description: description as string,
-      version: version as string,
-      author: author as string
+      name,
+      description,
+      version,
+      author
     }
 
-    const dockerConfig = await this.initializeDockerConfig(name as string)
+    const dockerConfig = await this.initializeDockerConfig(name)
 
     const changes = this.getConfigChanges(currentConfig, config, dockerConfig)
 
@@ -414,12 +379,12 @@ export class InitProjectCommand extends CommandRunner {
       console.log('\nNo changes to apply.')
     }
 
-    const shouldWrite = await confirm({
+    const shouldWrite = await this.promptService.confirm({
       message: 'Write changes?'
     })
 
-    if (isCancel(shouldWrite) || !shouldWrite) {
-      cancel('Operation cancelled.')
+    if (!shouldWrite) {
+      console.log('Operation cancelled.')
       process.exit(0)
     }
 

--- a/src/shared/prompt/index.ts
+++ b/src/shared/prompt/index.ts
@@ -1,0 +1,3 @@
+export * from './prompt.module'
+export * from './prompt.service'
+export * from './prompter.interface'

--- a/src/shared/prompt/interfaces/confirm-prompter.interface.ts
+++ b/src/shared/prompt/interfaces/confirm-prompter.interface.ts
@@ -1,0 +1,3 @@
+export interface ConfirmOptions {
+  message: string
+}

--- a/src/shared/prompt/interfaces/index.ts
+++ b/src/shared/prompt/interfaces/index.ts
@@ -1,0 +1,4 @@
+export * from './confirm-prompter.interface'
+export * from './select-prompter.interface'
+export * from './spinner-prompter.interface'
+export * from './text-prompter.interface'

--- a/src/shared/prompt/interfaces/select-prompter.interface.ts
+++ b/src/shared/prompt/interfaces/select-prompter.interface.ts
@@ -1,0 +1,9 @@
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+export interface SelectOptions {
+  message: string
+  options: SelectOption[]
+}

--- a/src/shared/prompt/interfaces/spinner-prompter.interface.ts
+++ b/src/shared/prompt/interfaces/spinner-prompter.interface.ts
@@ -1,0 +1,3 @@
+export interface SpinnerOptions {
+  message: string
+}

--- a/src/shared/prompt/interfaces/text-prompter.interface.ts
+++ b/src/shared/prompt/interfaces/text-prompter.interface.ts
@@ -1,0 +1,6 @@
+export interface TextOptions {
+  message: string
+  placeholder?: string
+  defaultValue?: string
+  validate?: (value: string) => string | undefined
+}

--- a/src/shared/prompt/prompt.module.ts
+++ b/src/shared/prompt/prompt.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+
+import { PromptService } from './prompt.service'
+
+@Module({
+  providers: [PromptService],
+  exports: [PromptService]
+})
+export class PromptModule {}

--- a/src/shared/prompt/prompt.service.spec.ts
+++ b/src/shared/prompt/prompt.service.spec.ts
@@ -1,0 +1,177 @@
+import * as clack from '@clack/prompts'
+
+import { PromptService } from './prompt.service'
+
+jest.mock('@clack/prompts')
+
+describe('PromptService', () => {
+  let service: PromptService
+
+  beforeEach(() => {
+    ;(clack.text as jest.Mock).mockReset()
+    ;(clack.select as jest.Mock).mockReset()
+    ;(clack.confirm as jest.Mock).mockReset()
+    ;(clack.spinner as jest.Mock).mockReset()
+    ;(clack.cancel as jest.Mock).mockReset()
+    ;(clack.isCancel as unknown as jest.Mock).mockReset()
+    service = new PromptService()
+  })
+
+  describe('text', () => {
+    it('should return text value when not cancelled', async () => {
+      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
+
+      const result = await service.text({
+        message: 'Enter name:',
+        placeholder: 'name',
+        defaultValue: 'default'
+      })
+
+      expect(result).toBe('test-value')
+      expect(clack.text).toHaveBeenCalledWith({
+        message: 'Enter name:',
+        placeholder: 'name',
+        defaultValue: 'default',
+        validate: undefined
+      })
+    })
+
+    it('should call validate function', async () => {
+      ;(clack.text as jest.Mock).mockResolvedValue('test-value')
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
+      const validate = jest.fn()
+
+      await service.text({
+        message: 'Enter name:',
+        validate
+      })
+
+      expect(clack.text).toHaveBeenCalledWith({
+        message: 'Enter name:',
+        validate
+      })
+    })
+
+    it('should exit when cancelled', async () => {
+      ;(clack.text as jest.Mock).mockResolvedValue(Symbol('cancel'))
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(true)
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation()
+
+      await service.text({ message: 'Enter name:' })
+
+      expect(clack.cancel).toHaveBeenCalledWith('Operation cancelled.')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('select', () => {
+    it('should return selected value when not cancelled', async () => {
+      ;(clack.select as jest.Mock).mockResolvedValue('pnpm')
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
+
+      const result = await service.select({
+        message: 'Select package manager:',
+        options: [
+          { value: 'pnpm', label: 'pnpm' },
+          { value: 'npm', label: 'npm' }
+        ]
+      })
+
+      expect(result).toBe('pnpm')
+      expect(clack.select).toHaveBeenCalledWith({
+        message: 'Select package manager:',
+        options: [
+          { value: 'pnpm', label: 'pnpm' },
+          { value: 'npm', label: 'npm' }
+        ]
+      })
+    })
+
+    it('should exit when cancelled', async () => {
+      ;(clack.select as jest.Mock).mockResolvedValue(Symbol('cancel'))
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(true)
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation()
+
+      await service.select({
+        message: 'Select option:',
+        options: [{ value: 'a', label: 'A' }]
+      })
+
+      expect(clack.cancel).toHaveBeenCalledWith('Operation cancelled.')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('confirm', () => {
+    it('should return true when confirmed', async () => {
+      ;(clack.confirm as jest.Mock).mockResolvedValue(true)
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
+
+      const result = await service.confirm({ message: 'Continue?' })
+
+      expect(result).toBe(true)
+      expect(clack.confirm).toHaveBeenCalledWith({ message: 'Continue?' })
+    })
+
+    it('should return false when rejected', async () => {
+      ;(clack.confirm as jest.Mock).mockResolvedValue(false)
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(false)
+
+      const result = await service.confirm({ message: 'Continue?' })
+
+      expect(result).toBe(false)
+    })
+
+    it('should exit when cancelled', async () => {
+      ;(clack.confirm as jest.Mock).mockResolvedValue(Symbol('cancel'))
+      ;(clack.isCancel as unknown as jest.Mock).mockReturnValue(true)
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation()
+
+      await service.confirm({ message: 'Continue?' })
+
+      expect(clack.cancel).toHaveBeenCalledWith('Operation cancelled.')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+    })
+  })
+
+  describe('spinner', () => {
+    it('should execute function and stop with Done', async () => {
+      const mockSpinner = { start: jest.fn(), stop: jest.fn() }
+      ;(clack.spinner as jest.Mock).mockReturnValue(mockSpinner)
+      const fn = jest.fn().mockResolvedValue('result')
+
+      const result = await service.spinner({ message: 'Working...' }, fn)
+
+      expect(result).toBe('result')
+      expect(mockSpinner.start).toHaveBeenCalledWith('Working...')
+      expect(mockSpinner.stop).toHaveBeenCalledWith('Done')
+    })
+
+    it('should stop with Failed on error', async () => {
+      const mockSpinner = { start: jest.fn(), stop: jest.fn() }
+      ;(clack.spinner as jest.Mock).mockReturnValue(mockSpinner)
+      const error = new Error('test error')
+      const fn = jest.fn().mockRejectedValue(error)
+
+      await expect(service.spinner({ message: 'Working...' }, fn)).rejects.toThrow(error)
+      expect(mockSpinner.start).toHaveBeenCalledWith('Working...')
+      expect(mockSpinner.stop).toHaveBeenCalledWith('Failed')
+    })
+  })
+
+  describe('spinnerMessage', () => {
+    it('should return start and stop functions', () => {
+      const mockSpinner = { start: jest.fn(), stop: jest.fn() }
+      ;(clack.spinner as jest.Mock).mockReturnValue(mockSpinner)
+
+      const { start, stop } = service.spinnerMessage({ message: 'Working...' })
+
+      start()
+      stop('Done')
+
+      expect(mockSpinner.start).toHaveBeenCalledWith('Working...')
+      expect(mockSpinner.stop).toHaveBeenCalledWith('Done')
+    })
+  })
+})

--- a/src/shared/prompt/prompt.service.ts
+++ b/src/shared/prompt/prompt.service.ts
@@ -1,0 +1,70 @@
+import { cancel, confirm, isCancel, select, spinner, text } from '@clack/prompts'
+
+import type { ConfirmOptions, SelectOptions, SpinnerOptions, TextOptions } from './interfaces'
+
+export class PromptService {
+  async text(options: TextOptions): Promise<string> {
+    const result = await text({
+      message: options.message,
+      placeholder: options.placeholder,
+      defaultValue: options.defaultValue,
+      validate: options.validate
+    })
+
+    if (isCancel(result)) {
+      cancel('Operation cancelled.')
+      process.exit(0)
+    }
+
+    return result as string
+  }
+
+  async select(options: SelectOptions): Promise<string> {
+    const result = await select({
+      message: options.message,
+      options: options.options
+    })
+
+    if (isCancel(result)) {
+      cancel('Operation cancelled.')
+      process.exit(0)
+    }
+
+    return result as string
+  }
+
+  async confirm(options: ConfirmOptions): Promise<boolean> {
+    const result = await confirm({
+      message: options.message
+    })
+
+    if (isCancel(result)) {
+      cancel('Operation cancelled.')
+      process.exit(0)
+    }
+
+    return result as boolean
+  }
+
+  async spinner<T>(options: SpinnerOptions, fn: () => Promise<T>): Promise<T> {
+    const s = spinner()
+    s.start(options.message)
+
+    try {
+      const result = await fn()
+      s.stop('Done')
+      return result
+    } catch (error) {
+      s.stop('Failed')
+      throw error
+    }
+  }
+
+  spinnerMessage(options: SpinnerOptions): { start: () => void; stop: (message?: string) => void } {
+    const s = spinner()
+    return {
+      start: () => s.start(options.message),
+      stop: (message?: string) => s.stop(message)
+    }
+  }
+}

--- a/src/shared/prompt/prompter.interface.ts
+++ b/src/shared/prompt/prompter.interface.ts
@@ -1,0 +1,11 @@
+import type { ConfirmOptions, SelectOptions, SpinnerOptions, TextOptions } from './interfaces'
+
+export interface Prompter {
+  text(options: TextOptions): Promise<string>
+  select(options: SelectOptions): Promise<string>
+  confirm(options: ConfirmOptions): Promise<boolean>
+  spinner<T>(options: SpinnerOptions, fn: () => Promise<T>): Promise<T>
+  spinnerMessage(options: SpinnerOptions): { start: () => void; stop: (message?: string) => void }
+}
+
+export * from './interfaces'

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -2,9 +2,10 @@ import { Global, Module } from '@nestjs/common'
 import { ErrorModule } from './errors/error.module'
 import { FileHandlerModule } from './file-handler'
 import { ProcessModule } from './process'
+import { PromptModule } from './prompt'
 
 @Global()
 @Module({
-  imports: [ErrorModule, FileHandlerModule, ProcessModule]
+  imports: [ErrorModule, FileHandlerModule, ProcessModule, PromptModule]
 })
 export class SharedModule {}

--- a/src/shared/utils.helper.spec.ts
+++ b/src/shared/utils.helper.spec.ts
@@ -1,9 +1,108 @@
-import { isEmptyObject } from './utils.helper'
+import {
+  getCalver,
+  isEmptyObject,
+  validateCalver,
+  validateKebabCase,
+  validateSemver
+} from './utils.helper'
 
 describe('UtilsHelper', () => {
-  it('Should check isEmptyObject', () => {
-    expect(isEmptyObject).toBeDefined()
-    expect(isEmptyObject({})).toBeTruthy()
-    expect(isEmptyObject({ key: 'value' })).toBeFalsy()
+  describe('isEmptyObject', () => {
+    it('should check isEmptyObject', () => {
+      expect(isEmptyObject).toBeDefined()
+      expect(isEmptyObject({})).toBeTruthy()
+      expect(isEmptyObject({ key: 'value' })).toBeFalsy()
+    })
+  })
+
+  describe('validateKebabCase', () => {
+    it('should return undefined for valid kebab-case', () => {
+      expect(validateKebabCase('my-project')).toBeUndefined()
+      expect(validateKebabCase('a')).toBeUndefined()
+      expect(validateKebabCase('a1')).toBeUndefined()
+      expect(validateKebabCase('a1-b2-c3')).toBeUndefined()
+    })
+
+    it('should return error message for invalid kebab-case', () => {
+      expect(validateKebabCase('MyProject')).toBe(
+        'Name must be kebab-case (lowercase, numbers, hyphens)'
+      )
+      expect(validateKebabCase('my_project')).toBe(
+        'Name must be kebab-case (lowercase, numbers, hyphens)'
+      )
+      expect(validateKebabCase('my.project')).toBe(
+        'Name must be kebab-case (lowercase, numbers, hyphens)'
+      )
+      expect(validateKebabCase('my project')).toBe(
+        'Name must be kebab-case (lowercase, numbers, hyphens)'
+      )
+    })
+
+    it('should return undefined for empty value', () => {
+      expect(validateKebabCase('')).toBeUndefined()
+      expect(validateKebabCase(undefined as unknown as string)).toBeUndefined()
+    })
+  })
+
+  describe('validateSemver', () => {
+    it('should return undefined for valid semver', () => {
+      expect(validateSemver('1.0.0')).toBeUndefined()
+      expect(validateSemver('0.1.0')).toBeUndefined()
+      expect(validateSemver('10.20.30')).toBeUndefined()
+    })
+
+    it('should return error message for invalid semver', () => {
+      expect(validateSemver('abc')).toBe('Must be semver format (x.y.z)')
+      expect(validateSemver('1.0')).toBe('Must be semver format (x.y.z)')
+      expect(validateSemver('v1.0.0')).toBe('Must be semver format (x.y.z)')
+    })
+
+    it('should return undefined for empty value', () => {
+      expect(validateSemver('')).toBeUndefined()
+      expect(validateSemver(undefined as unknown as string)).toBeUndefined()
+    })
+  })
+
+  describe('validateCalver', () => {
+    it('should return undefined for valid calver', () => {
+      expect(validateCalver('2024.03.1')).toBeUndefined()
+      expect(validateCalver('2024.3.0')).toBeUndefined()
+      expect(validateCalver('2024.12.31')).toBeUndefined()
+    })
+
+    it('should return error message for invalid calver', () => {
+      expect(validateCalver('abc')).toBe('Must be calver format (YYYY.M.PATCH)')
+      expect(validateCalver('1.0.0')).toBe('Must be calver format (YYYY.M.PATCH)')
+      expect(validateCalver('24.03.1')).toBe('Must be calver format (YYYY.M.PATCH)')
+    })
+
+    it('should return undefined for empty value', () => {
+      expect(validateCalver('')).toBeUndefined()
+      expect(validateCalver(undefined as unknown as string)).toBeUndefined()
+    })
+  })
+
+  describe('getCalver', () => {
+    it('should return today in YYYY.MM.DD format', () => {
+      const result = getCalver()
+      expect(result).toMatch(/^\d{4}\.\d{2}\.\d{2}$/)
+      const [year, month, day] = result.split('.').map(Number)
+      const today = new Date()
+      expect(year).toBe(today.getFullYear())
+      expect(month).toBe(today.getMonth() + 1)
+      expect(day).toBe(today.getDate())
+    })
+
+    it('should return given date in YYYY.MM.DD format', () => {
+      const date = new Date(2024, 2, 15)
+      const result = getCalver(date)
+      expect(result).toBe('2024.03.15')
+    })
+
+    it('should pad single digit month and day', () => {
+      const date = new Date(2024, 0, 5)
+      const result = getCalver(date)
+      expect(result).toBe('2024.01.05')
+    })
   })
 })

--- a/src/shared/utils.helper.ts
+++ b/src/shared/utils.helper.ts
@@ -7,3 +7,58 @@
 export const isEmptyObject = (objectName: object): boolean => {
   return objectName && Object.keys(objectName).length === 0 && objectName.constructor === Object
 }
+
+/**
+ * Validates kebab-case string (lowercase, numbers, hyphens)
+ *
+ * @param value String to validate
+ * @returns {string | undefined} Error message or undefined if valid
+ */
+export const validateKebabCase = (value: string): string | undefined => {
+  if (!value || value.length === 0) return undefined
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(value)) {
+    return 'Name must be kebab-case (lowercase, numbers, hyphens)'
+  }
+  return undefined
+}
+
+/**
+ * Validates semver format (x.y.z)
+ *
+ * @param value String to validate
+ * @returns {string | undefined} Error message or undefined if valid
+ */
+export const validateSemver = (value: string): string | undefined => {
+  if (!value || value.length === 0) return undefined
+  if (!/^\d+\.\d+\.\d+/.test(value)) {
+    return 'Must be semver format (x.y.z)'
+  }
+  return undefined
+}
+
+/**
+ * Validates calver format (YYYY.M.PATCH)
+ *
+ * @param value String to validate
+ * @returns {string | undefined} Error message or undefined if valid
+ */
+export const validateCalver = (value: string): string | undefined => {
+  if (!value || value.length === 0) return undefined
+  if (!/^\d{4}\.\d{1,2}\.\d+/.test(value)) {
+    return 'Must be calver format (YYYY.M.PATCH)'
+  }
+  return undefined
+}
+
+/**
+ * Gets current date in calver format (YYYY.MM.DD)
+ *
+ * @param date Date to format (defaults to now)
+ * @returns {string} Formatted calver string
+ */
+export const getCalver = (date: Date = new Date()): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}


### PR DESCRIPTION
## Summary
- Create PromptService module with ISP-based interfaces (TextPrompter, SelectPrompter, ConfirmPrompter, SpinnerPrompter)
- Add auto-cancel handling - when user cancels, displays message and exits
- Add validation utilities to utils.helper.ts (validateKebabCase, validateSemver, validateCalver, getCalver)
- Update init-project.command.ts to use new services
- Remove 9 identical cancel-handling patterns

## Changes
- `src/shared/prompt/` - New PromptService module
- `src/shared/utils.helper.ts` - Added validation functions
- `src/cli/commands/init-project.command.ts` - Refactored to use new services
- `.paw-tools/main.md` - Updated documentation

## Testing
- 127 tests passing
- Coverage: 70.79% overall