### PR TITLE
fix: consolidate test mocks in test folder

### DIFF
--- a/.paw-tools/main.md
+++ b/.paw-tools/main.md
@@ -515,3 +515,30 @@ const today = getCalver() // "2026.03.24"
 // Or for a specific date
 const specific = getCalver(new Date('2024-01-15')) // "2024.01.15"
 ```
+
+## Testing
+
+All test-related files MUST be placed in the `test/` folder. This includes:
+
+- **Unit tests**: `src/**/*.spec.ts` (co-located with source)
+- **E2E tests**: `test/*.e2e-spec.ts`
+- **Test mocks**: `test/__mocks__/`
+
+### Test Mocks
+
+Mock files for external modules should be in `test/__mocks__/`:
+
+```
+test/
+├── __mocks__/
+│   └── @clack/
+│       └── prompts.ts    # Mock for @clack/prompts
+├── app.e2e-spec.ts
+└── jest-e2e.json
+```
+
+The jest config maps mocks to `test/__mocks__/`:
+- Unit tests (`jest.config.mjs`): `moduleNameMapper` points to `<rootDir>/../test/__mocks__/`
+- E2E tests (`test/jest-e2e.json`): `moduleNameMapper` points to `<rootDir>/__mocks__/`
+
+**Do NOT create mocks in `src/__mocks__/`**. All test mocks belong in `test/__mocks__/`.

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,11 +5,11 @@ export default {
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!(@clack|sisteransi)/)'],
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
+    '^@clack/prompts$': '<rootDir>/../test/__mocks__/@clack/prompts.ts',
   },
 };

--- a/src/__mocks__/@clack/prompts.ts
+++ b/src/__mocks__/@clack/prompts.ts
@@ -1,9 +1,0 @@
-export const text = jest.fn()
-export const confirm = jest.fn()
-export const select = jest.fn()
-export const spinner = jest.fn(() => ({
-  start: jest.fn(),
-  stop: jest.fn()
-}))
-export const cancel = jest.fn()
-export const isCancel = jest.fn(() => false)

--- a/test/__mocks__/@clack/prompts.ts
+++ b/test/__mocks__/@clack/prompts.ts
@@ -1,5 +1,6 @@
 export const text = jest.fn()
 export const confirm = jest.fn()
+export const select = jest.fn()
 export const spinner = jest.fn(() => ({
   start: jest.fn(),
   stop: jest.fn()


### PR DESCRIPTION
## Summary
- Add missing `select` export to `test/__mocks__/@clack/prompts.ts`
- Update `jest.config.mjs` to use `moduleNameMapper` for `@clack/prompts`
- Remove `src/__mocks__/` (mocks belong in test folder)
- Update AGENTS.md with testing documentation

## Changes
- `test/__mocks__/@clack/prompts.ts` - Added missing `select` export
- `jest.config.mjs` - Use moduleNameMapper instead of transformIgnorePatterns
- `.paw-tools/main.md` - Document that test-related files go in test folder

## Testing
- 127 tests passing
- Build passing
- Lint passing