### PR TITLE
feat: add ConsoleService for structured CLI logging

### DIFF
--- a/.paw-tools/main.md
+++ b/.paw-tools/main.md
@@ -408,6 +408,103 @@ const author = `${nameResult.stdout} <${emailResult.stdout}>`
 - Environment variables validated with Joi schema
 - Secrets should never be logged or committed
 
+## ConsoleModule
+
+All CLI output MUST use `ConsoleService`. Never use `console.log`, `console.warn`, or `console.error` directly in commands. The service provides structured logging with consistent formatting.
+
+### Location
+
+```
+src/shared/console/
+├── interfaces/
+│   ├── logger.interface.ts
+│   └── index.ts
+├── console.service.ts
+├── console.module.ts
+└── index.ts
+```
+
+### Usage
+
+```typescript
+import { ConsoleService } from '@/shared/console'
+
+export class MyCommand extends CommandRunner {
+  private readonly consoleService: ConsoleService
+
+  constructor() {
+    super()
+    this.consoleService = new ConsoleService()
+  }
+
+  async run() {
+    this.consoleService.info('Starting operation...')
+    this.consoleService.success('Operation completed!')
+    this.consoleService.warn('Warning message')
+    this.consoleService.error('Error occurred:', error)
+  }
+}
+```
+
+### Available Methods
+
+| Method | Description |
+|--------|-------------|
+| `info(message, ...args)` | General informational messages |
+| `success(message, ...args)` | Success messages (green) |
+| `warn(message, ...args)` | Warning messages (yellow) |
+| `error(message, ...args)` | Error messages (red) |
+| `debug(message, ...args)` | Debug messages |
+| `start(message)` | Start messages for long-running operations |
+| `done(message)` | Success messages (alias for success) |
+| `fail(message)` | Failure messages (red) |
+| `log(message, ...args)` | General log messages |
+
+**Do NOT use `console.log`, `console.warn`, or `console.error` directly in commands.**
+
+### Environment Variables
+
+Configure logging behavior with environment variables:
+
+| Variable | Options | Default | Description |
+|----------|---------|---------|-------------|
+| `APP_LOGGER_LEVELS` | `0-7` or `fatal`, `error`, `warn`, `log`, `info`, `success`, `debug`, `silent` | `3` (info) | Minimum log level |
+| `APP_LOGGER_TAG` | `true`/`false` | `false` | Show `[paw-tools]` prefix |
+| `APP_LOGGER_DATE` | `true`/`false` | `false` | Show timestamps |
+| `APP_LOGGER_FORMAT` | `pretty`/`json` | `pretty` | Output format |
+
+### Log Levels
+
+| Level | Name | Description |
+|-------|------|-------------|
+| 0 | fatal | Only fatal errors |
+| 1 | error | Errors and fatal |
+| 2 | warn | Warnings and below |
+| 3 | log | Normal logs |
+| 4 | info | Info and below (default) |
+| 5 | success | Success and below |
+| 6 | debug | Debug and below |
+| 7 | silent | No output |
+
+### Usage Examples
+
+```bash
+# Default (clean, pretty)
+pnpm cli:dev
+
+# Debug mode
+APP_LOGGER_LEVELS=6 pnpm cli:dev
+
+# Structured (CI-friendly)
+APP_LOGGER_TAG=true APP_LOGGER_DATE=true pnpm cli
+
+# JSON output (for log aggregation)
+APP_LOGGER_FORMAT=json pnpm cli
+
+# Errors only
+APP_LOGGER_LEVELS=1 pnpm cli
+```
+
 ## PromptModule
 
 All CLI prompts MUST use `PromptService`. Never use `@clack/prompts` directly in commands. The service handles cancel detection and provides a consistent user experience.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nestjs/mapped-types": "2.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "consola": "^3.4.2",
     "joi": "^18.0.2",
     "nest-commander": "^3.3.0",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       joi:
         specifier: ^18.0.2
         version: 18.0.2

--- a/src/cli/commands/init-project.command.spec.ts
+++ b/src/cli/commands/init-project.command.spec.ts
@@ -20,6 +20,18 @@ const mockPromptService = {
   spinnerMessage: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() }))
 }
 
+const mockConsoleService = {
+  info: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  start: jest.fn(),
+  done: jest.fn(),
+  fail: jest.fn(),
+  log: jest.fn()
+}
+
 jest.mock('node:fs')
 jest.mock('node:fs/promises')
 jest.mock('@/shared/file-handler', () => ({
@@ -27,6 +39,9 @@ jest.mock('@/shared/file-handler', () => ({
 }))
 jest.mock('@/shared/prompt', () => ({
   PromptService: jest.fn().mockImplementation(() => mockPromptService)
+}))
+jest.mock('@/shared/console', () => ({
+  ConsoleService: jest.fn().mockImplementation(() => mockConsoleService)
 }))
 
 jest.mock('yaml', () => {
@@ -190,9 +205,6 @@ jest.mock('@/shared/process', () => ({
 
 describe('InitProjectCommand', () => {
   let command: InitProjectCommand
-  let consoleSpy: jest.SpyInstance
-  let consoleWarnSpy: jest.SpyInstance
-  let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
     mockPromptService.text.mockReset()
@@ -208,19 +220,15 @@ describe('InitProjectCommand', () => {
     mockFileHandler.writeJson.mockReset()
     mockProcessService.exec.mockReset()
     mockProcessService.exec.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 })
+    mockConsoleService.info.mockReset()
+    mockConsoleService.success.mockReset()
+    mockConsoleService.warn.mockReset()
+    mockConsoleService.error.mockReset()
+    mockConsoleService.log.mockReset()
     mockFileHandler.exists.mockReturnValue(true)
     mockFileHandler.readFile.mockResolvedValue('{}')
     mockFileHandler.readJson.mockResolvedValue({})
     command = new InitProjectCommand()
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation()
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
-  })
-
-  afterEach(() => {
-    consoleSpy.mockRestore()
-    consoleWarnSpy.mockRestore()
-    consoleErrorSpy.mockRestore()
   })
 
   it('should be defined', () => {
@@ -274,7 +282,9 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeWithDefaults']()
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith('package.json not found, skipping update.')
+      expect(mockConsoleService.warn).toHaveBeenCalledWith(
+        'package.json not found, skipping update.'
+      )
     })
   })
 
@@ -321,8 +331,8 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(consoleSpy).toHaveBeenCalledWith('\nChanges to be applied:')
-      expect(consoleSpy).toHaveBeenCalledWith('  name: "current-name" → "new-name"')
+      expect(mockConsoleService.info).toHaveBeenCalledWith('\nChanges to be applied:')
+      expect(mockConsoleService.log).toHaveBeenCalledWith('  name: "current-name" → "new-name"')
     })
 
     it('should show no changes message when values are same', async () => {
@@ -350,7 +360,7 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(consoleSpy).toHaveBeenCalledWith('\nNo changes to apply.')
+      expect(mockConsoleService.info).toHaveBeenCalledWith('\nNo changes to apply.')
     })
 
     it('should use calver format when selected', async () => {
@@ -368,7 +378,7 @@ describe('InitProjectCommand', () => {
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
       expect(mockPromptService.select).toHaveBeenCalled()
-      expect(consoleSpy).toHaveBeenCalledWith(`  version: "0.1.0" → "${todayCalver}"`)
+      expect(mockConsoleService.log).toHaveBeenCalledWith(`  version: "0.1.0" → "${todayCalver}"`)
     })
 
     it('should update both package.json and docker-compose.yml when docker exists', async () => {
@@ -387,10 +397,10 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(consoleSpy).toHaveBeenCalledWith('\nChanges applied:')
-      expect(consoleSpy).toHaveBeenCalledWith('  ✓ package.json updated')
-      expect(consoleSpy).toHaveBeenCalledWith('  ✓ docker-compose.yml updated')
-      expect(consoleSpy).toHaveBeenCalledWith('\n✔ Project initialized successfully.')
+      expect(mockConsoleService.info).toHaveBeenCalledWith('\nChanges applied:')
+      expect(mockConsoleService.log).toHaveBeenCalledWith('  ✓ package.json updated')
+      expect(mockConsoleService.log).toHaveBeenCalledWith('  ✓ docker-compose.yml updated')
+      expect(mockConsoleService.success).toHaveBeenCalledWith('Project initialized successfully.')
       expect(mockFileHandler.writeJson).toHaveBeenCalled()
       expect(mockFileHandler.writeFile).toHaveBeenCalled()
     })
@@ -409,7 +419,7 @@ describe('InitProjectCommand', () => {
 
       await (command as Testable<InitProjectCommand>)['initializeInteractive']()
 
-      expect(consoleSpy).toHaveBeenCalledWith('  name: "my-project" → "my-awesome-app"')
+      expect(mockConsoleService.log).toHaveBeenCalledWith('  name: "my-project" → "my-awesome-app"')
     })
 
     it('should reject invalid names (not kebab-case)', async () => {
@@ -753,7 +763,7 @@ describe('InitProjectCommand', () => {
         author: 'test'
       })
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
         'Failed to update package.json:',
         expect.any(Error)
       )
@@ -771,7 +781,7 @@ describe('InitProjectCommand', () => {
         author: 'test'
       })
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
         'Failed to update package.json:',
         expect.any(Error)
       )
@@ -852,7 +862,7 @@ describe('InitProjectCommand', () => {
         registryUrl: 'https://registry.npmjs.org/'
       })
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
         'Failed to update docker-compose.yml:',
         expect.any(Error)
       )

--- a/src/cli/commands/init-project.command.ts
+++ b/src/cli/commands/init-project.command.ts
@@ -1,10 +1,9 @@
-// biome-ignore-all lint/suspicious/noConsole: CLI command output
-
 import { join } from 'node:path'
 
 import { Command, CommandRunner, Option } from 'nest-commander'
 import { isMap, isPair, isScalar, type Pair, parseDocument, type Scalar, type YAMLMap } from 'yaml'
 
+import { ConsoleService } from '@/shared/console'
 import { FileHandlerService } from '@/shared/file-handler'
 import { ProcessService } from '@/shared/process'
 import { PromptService } from '@/shared/prompt'
@@ -38,12 +37,14 @@ export class InitProjectCommand extends CommandRunner {
   private readonly fileHandler: FileHandlerService
   private readonly processService: ProcessService
   private readonly promptService: PromptService
+  private readonly consoleService: ConsoleService
 
   constructor() {
     super()
     this.fileHandler = new FileHandlerService()
     this.processService = new ProcessService()
     this.promptService = new PromptService()
+    this.consoleService = new ConsoleService()
   }
 
   private getVersionPlaceholder(format: string): string {
@@ -208,7 +209,7 @@ export class InitProjectCommand extends CommandRunner {
     const packageJsonPath = join(process.cwd(), 'package.json')
 
     if (!this.fileHandler.exists(packageJsonPath)) {
-      console.warn('package.json not found, skipping update.')
+      this.consoleService.warn('package.json not found, skipping update.')
       return
     }
 
@@ -220,7 +221,7 @@ export class InitProjectCommand extends CommandRunner {
       packageJson.author = config.author || packageJson.author
       await this.fileHandler.writeJson(packageJsonPath, packageJson)
     } catch (error) {
-      console.error('Failed to update package.json:', error)
+      this.consoleService.error('Failed to update package.json:', error)
     }
   }
 
@@ -232,7 +233,7 @@ export class InitProjectCommand extends CommandRunner {
       const doc = parseDocument(fileContents)
 
       if (!isMap(doc.contents)) {
-        console.warn('Invalid docker-compose.yml structure')
+        this.consoleService.warn('Invalid docker-compose.yml structure')
         return
       }
 
@@ -241,7 +242,7 @@ export class InitProjectCommand extends CommandRunner {
 
       const servicesPair = doc.contents.items.find((pair) => hasScalarKey(pair, 'services'))
       if (!servicesPair || !isMap(servicesPair.value)) {
-        console.warn('services not found in docker-compose.yml')
+        this.consoleService.warn('services not found in docker-compose.yml')
         return
       }
 
@@ -249,7 +250,7 @@ export class InitProjectCommand extends CommandRunner {
         hasScalarKey(pair, this.mainServiceName)
       )
       if (!mainServicePair || !isMap(mainServicePair.value)) {
-        console.warn(`${this.mainServiceName} service not found in docker-compose.yml`)
+        this.consoleService.warn(`${this.mainServiceName} service not found in docker-compose.yml`)
         return
       }
 
@@ -285,7 +286,7 @@ export class InitProjectCommand extends CommandRunner {
 
       await this.fileHandler.writeFile(dockerComposePath, yamlContent)
     } catch (error) {
-      console.error('Failed to update docker-compose.yml:', error)
+      this.consoleService.error('Failed to update docker-compose.yml:', error)
     }
   }
 
@@ -311,11 +312,11 @@ export class InitProjectCommand extends CommandRunner {
     }
 
     s.stop('Changes applied:')
-    console.log('  ✓ package.json updated')
+    this.consoleService.log('  ✓ package.json updated')
     if (this.fileHandler.exists(dockerComposePath)) {
-      console.log('  ✓ docker-compose.yml updated')
+      this.consoleService.log('  ✓ docker-compose.yml updated')
     }
-    console.log('\n✔ Project initialized successfully.')
+    this.consoleService.success('Project initialized successfully.')
   }
 
   private async initializeInteractive(): Promise<void> {
@@ -371,12 +372,12 @@ export class InitProjectCommand extends CommandRunner {
     const changes = this.getConfigChanges(currentConfig, config, dockerConfig)
 
     if (changes.length > 0) {
-      console.log('\nChanges to be applied:')
+      this.consoleService.info('\nChanges to be applied:')
       for (const change of changes) {
-        console.log(`  ${change}`)
+        this.consoleService.log(`  ${change}`)
       }
     } else {
-      console.log('\nNo changes to apply.')
+      this.consoleService.info('\nNo changes to apply.')
     }
 
     const shouldWrite = await this.promptService.confirm({
@@ -384,7 +385,7 @@ export class InitProjectCommand extends CommandRunner {
     })
 
     if (!shouldWrite) {
-      console.log('Operation cancelled.')
+      this.consoleService.info('Operation cancelled.')
       process.exit(0)
     }
 
@@ -393,14 +394,14 @@ export class InitProjectCommand extends CommandRunner {
       if (dockerConfig) {
         await this.updateDockerCompose(dockerConfig)
       }
-      console.log('\nChanges applied:')
-      console.log('  ✓ package.json updated')
+      this.consoleService.info('\nChanges applied:')
+      this.consoleService.log('  ✓ package.json updated')
       if (dockerConfig) {
-        console.log('  ✓ docker-compose.yml updated')
+        this.consoleService.log('  ✓ docker-compose.yml updated')
       }
-      console.log('\n✔ Project initialized successfully.')
+      this.consoleService.success('Project initialized successfully.')
     } catch (error) {
-      console.error('Failed to update project:', error)
+      this.consoleService.error('Failed to update project:', error)
     }
   }
 

--- a/src/shared/console/console.module.ts
+++ b/src/shared/console/console.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+
+import { ConsoleService } from './console.service'
+
+@Module({
+  providers: [ConsoleService],
+  exports: [ConsoleService]
+})
+export class ConsoleModule {}

--- a/src/shared/console/console.service.ts
+++ b/src/shared/console/console.service.ts
@@ -1,0 +1,96 @@
+import { type ConsolaInstance, createConsola } from 'consola'
+
+import type { Logger } from './interfaces'
+
+const LOG_LEVELS = {
+  fatal: 0,
+  error: 1,
+  warn: 2,
+  log: 3,
+  info: 4,
+  success: 5,
+  debug: 6,
+  trace: 7,
+  silent: Infinity
+} as const
+
+function parseLogLevel(level: string | undefined): number {
+  if (!level) return 3
+  if (level in LOG_LEVELS) return LOG_LEVELS[level as keyof typeof LOG_LEVELS]
+  const num = Number.parseInt(level, 10)
+  return Number.isNaN(num) ? 3 : num
+}
+
+export class ConsoleService implements Logger {
+  private readonly logger: ConsolaInstance
+
+  constructor() {
+    const levels = process.env.APP_LOGGER_LEVELS
+    const showTag = process.env.APP_LOGGER_TAG === 'true'
+    const showDate = process.env.APP_LOGGER_DATE === 'true'
+    const format = process.env.APP_LOGGER_FORMAT
+
+    const level = parseLogLevel(levels)
+
+    if (format === 'json') {
+      this.logger = createConsola({
+        level,
+        reporters: [
+          {
+            log: (logObj) => {
+              process.stdout.write(`${JSON.stringify(logObj)}\n`)
+            }
+          }
+        ]
+      })
+    } else {
+      this.logger = createConsola({
+        level,
+        formatOptions: {
+          date: showDate,
+          colors: true
+        }
+      })
+
+      if (showTag) {
+        this.logger = this.logger.withTag('paw-tools')
+      }
+    }
+  }
+
+  info(message: string, ...args: unknown[]): void {
+    this.logger.info(message, ...args)
+  }
+
+  success(message: string, ...args: unknown[]): void {
+    this.logger.success(message, ...args)
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    this.logger.warn(message, ...args)
+  }
+
+  error(message: string, ...args: unknown[]): void {
+    this.logger.error(message, ...args)
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    this.logger.debug(message, ...args)
+  }
+
+  start(message: string): void {
+    this.logger.start(message)
+  }
+
+  done(message: string): void {
+    this.logger.success(message)
+  }
+
+  fail(message: string): void {
+    this.logger.fail(message)
+  }
+
+  log(message: string, ...args: unknown[]): void {
+    this.logger.log(message, ...args)
+  }
+}

--- a/src/shared/console/index.ts
+++ b/src/shared/console/index.ts
@@ -1,0 +1,3 @@
+export * from './console.module'
+export * from './console.service'
+export * from './interfaces'

--- a/src/shared/console/interfaces/index.ts
+++ b/src/shared/console/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './logger.interface'

--- a/src/shared/console/interfaces/logger.interface.ts
+++ b/src/shared/console/interfaces/logger.interface.ts
@@ -1,0 +1,11 @@
+export interface Logger {
+  info(message: string, ...args: unknown[]): void
+  success(message: string, ...args: unknown[]): void
+  warn(message: string, ...args: unknown[]): void
+  error(message: string, ...args: unknown[]): void
+  debug(message: string, ...args: unknown[]): void
+  start(message: string): void
+  done(message: string): void
+  fail(message: string): void
+  log(message: string, ...args: unknown[]): void
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common'
+import { ConsoleModule } from './console'
 import { ErrorModule } from './errors/error.module'
 import { FileHandlerModule } from './file-handler'
 import { ProcessModule } from './process'
@@ -6,6 +7,6 @@ import { PromptModule } from './prompt'
 
 @Global()
 @Module({
-  imports: [ErrorModule, FileHandlerModule, ProcessModule, PromptModule]
+  imports: [ConsoleModule, ErrorModule, FileHandlerModule, ProcessModule, PromptModule]
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- Create ConsoleService module wrapping consola
- Add configurable logging via environment variables:
  - `APP_LOGGER_LEVELS`: Log level (0-7 or named levels)
  - `APP_LOGGER_TAG`: Show `[paw-tools]` prefix
  - `APP_LOGGER_DATE`: Show timestamps
  - `APP_LOGGER_FORMAT`: `pretty` (default) or `json` output format
- Add ISP-based Logger interface
- Methods: info, success, warn, error, debug, start, done, fail, log
- Update init-project.command.ts to use ConsoleService
- Replace all console.log/warn/error with structured logging

## Configuration Examples

```bash
# Default (clean, pretty)
pnpm cli:dev

# Debug mode
APP_LOGGER_LEVELS=6 pnpm cli:dev

# Structured (CI-friendly)
APP_LOGGER_TAG=true APP_LOGGER_DATE=true pnpm cli

# JSON output
APP_LOGGER_FORMAT=json pnpm cli
```

## Testing
- 127 tests passing
- Build passing
- Lint passing