### PR TITLE
fix: use ConsoleService in all commands and fix env var consistency

### DIFF
--- a/src/cli/commands/config.command.spec.ts
+++ b/src/cli/commands/config.command.spec.ts
@@ -9,9 +9,24 @@ const mockFileHandler = {
   readJson: jest.fn().mockResolvedValue({ app: { debug: true } })
 }
 
+const mockConsoleService = {
+  info: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  start: jest.fn(),
+  done: jest.fn(),
+  fail: jest.fn(),
+  log: jest.fn()
+}
+
 jest.mock('node:fs')
 jest.mock('@/shared/file-handler', () => ({
   FileHandlerService: jest.fn().mockImplementation(() => mockFileHandler)
+}))
+jest.mock('@/shared/console', () => ({
+  ConsoleService: jest.fn().mockImplementation(() => mockConsoleService)
 }))
 
 describe('ConfigCommand', () => {
@@ -24,6 +39,7 @@ describe('ConfigCommand', () => {
     delete process.env.PAW_CONFIG
     mockFileHandler.exists.mockReturnValue(true)
     mockFileHandler.readJson.mockResolvedValue({ app: { debug: true } })
+    mockConsoleService.success.mockClear()
     command = new ConfigCommand()
   })
 
@@ -107,6 +123,16 @@ describe('ConfigCommand', () => {
     it('should return the provided value', () => {
       const result = command.parseConfig('/custom/path.json')
       expect(result).toBe('/custom/path.json')
+    })
+  })
+
+  describe('run', () => {
+    it('should output success message', async () => {
+      await command.run([])
+
+      expect(mockConsoleService.success).toHaveBeenCalledWith(
+        expect.stringContaining('Configuration loaded successfully')
+      )
     })
   })
 })

--- a/src/cli/commands/config.command.ts
+++ b/src/cli/commands/config.command.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 
 import { Command, CommandRunner, Option } from 'nest-commander'
 
+import { ConsoleService } from '@/shared/console'
 import { FileHandlerService } from '@/shared/file-handler'
 
 interface ConfigCommandOptions {
@@ -14,10 +15,12 @@ interface ConfigCommandOptions {
 })
 export class ConfigCommand extends CommandRunner {
   private readonly fileHandler: FileHandlerService
+  private readonly consoleService: ConsoleService
 
   constructor() {
     super()
     this.fileHandler = new FileHandlerService()
+    this.consoleService = new ConsoleService()
   }
 
   private resolveConfigPath(customPath?: string): string {
@@ -52,7 +55,6 @@ export class ConfigCommand extends CommandRunner {
     const configPath = this.resolveConfigPath(options?.config)
     const config = await this.loadConfig(configPath)
     this.validateConfig(config)
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log('Configuration loaded successfully:', configPath)
+    this.consoleService.success(`Configuration loaded successfully: ${configPath}`)
   }
 }

--- a/src/cli/commands/generate-secret.command.spec.ts
+++ b/src/cli/commands/generate-secret.command.spec.ts
@@ -1,16 +1,27 @@
 import { GenerateSecretCommand } from './generate-secret.command'
 
+const mockConsoleService = {
+  info: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  start: jest.fn(),
+  done: jest.fn(),
+  fail: jest.fn(),
+  log: jest.fn()
+}
+
+jest.mock('@/shared/console', () => ({
+  ConsoleService: jest.fn().mockImplementation(() => mockConsoleService)
+}))
+
 describe('GenerateSecretCommand', () => {
   let command: GenerateSecretCommand
-  let consoleSpy: jest.SpyInstance
 
   beforeEach(() => {
     command = new GenerateSecretCommand()
-    consoleSpy = jest.spyOn(console, 'log').mockImplementation()
-  })
-
-  afterEach(() => {
-    consoleSpy.mockRestore()
+    mockConsoleService.success.mockClear()
   })
 
   it('should be defined', () => {
@@ -20,8 +31,8 @@ describe('GenerateSecretCommand', () => {
   it('should generate 32-byte hex string (64 characters)', async () => {
     await command.run()
 
-    expect(consoleSpy).toHaveBeenCalledTimes(1)
-    const secretKey = consoleSpy.mock.calls[0][0]
+    expect(mockConsoleService.success).toHaveBeenCalledTimes(1)
+    const secretKey = mockConsoleService.success.mock.calls[0][0]
     expect(secretKey).toMatch(/^[a-f0-9]{64}$/)
   })
 
@@ -29,9 +40,9 @@ describe('GenerateSecretCommand', () => {
     const keys = new Set<string>()
 
     for (let i = 0; i < 10; i++) {
-      consoleSpy.mockClear()
+      mockConsoleService.success.mockClear()
       await command.run()
-      const key = consoleSpy.mock.calls[0][0]
+      const key = mockConsoleService.success.mock.calls[0][0]
       keys.add(key)
     }
 

--- a/src/cli/commands/generate-secret.command.ts
+++ b/src/cli/commands/generate-secret.command.ts
@@ -2,14 +2,22 @@ import { randomBytes } from 'node:crypto'
 
 import { Command, CommandRunner } from 'nest-commander'
 
+import { ConsoleService } from '@/shared/console'
+
 @Command({
   name: 'generate-secret',
   description: 'Generate a random secret key'
 })
 export class GenerateSecretCommand extends CommandRunner {
+  private readonly consoleService: ConsoleService
+
+  constructor() {
+    super()
+    this.consoleService = new ConsoleService()
+  }
+
   async run(): Promise<void> {
     const secretKey = randomBytes(32).toString('hex')
-    // biome-ignore lint/suspicious/noConsole: CLI output
-    console.log(secretKey)
+    this.consoleService.success(secretKey)
   }
 }

--- a/src/config/logger/logger.config.spec.ts
+++ b/src/config/logger/logger.config.spec.ts
@@ -13,15 +13,15 @@ describe('LoggerConfig', () => {
   })
 
   it('should use default log levels when env not set', () => {
-    delete process.env.API_LOGGER_LEVELS
+    delete process.env.APP_LOGGER_LEVELS
 
     const { logLevel } = require('./logger.config')
 
     expect(logLevel).toEqual(['log', 'error', 'warn', 'debug', 'verbose', 'fatal'])
   })
 
-  it('should parse custom log levels from API_LOGGER_LEVELS', () => {
-    process.env.API_LOGGER_LEVELS = 'log,error,warn'
+  it('should parse custom log levels from APP_LOGGER_LEVELS', () => {
+    process.env.APP_LOGGER_LEVELS = 'log,error,warn'
 
     const { logLevel } = require('./logger.config')
 
@@ -29,15 +29,15 @@ describe('LoggerConfig', () => {
   })
 
   it('should handle single log level', () => {
-    process.env.API_LOGGER_LEVELS = 'error'
+    process.env.APP_LOGGER_LEVELS = 'error'
 
     const { logLevel } = require('./logger.config')
 
     expect(logLevel).toEqual(['error'])
   })
 
-  it('should handle empty API_LOGGER_LEVELS', () => {
-    process.env.API_LOGGER_LEVELS = ''
+  it('should handle empty APP_LOGGER_LEVELS', () => {
+    process.env.APP_LOGGER_LEVELS = ''
 
     const { logLevel } = require('./logger.config')
 
@@ -46,7 +46,7 @@ describe('LoggerConfig', () => {
 
   it('should handle all NestJS log levels', () => {
     const allLevels: LogLevel[] = ['log', 'error', 'warn', 'debug', 'verbose', 'fatal']
-    process.env.API_LOGGER_LEVELS = allLevels.join(',')
+    process.env.APP_LOGGER_LEVELS = allLevels.join(',')
 
     const { logLevel } = require('./logger.config')
 

--- a/src/config/logger/logger.config.ts
+++ b/src/config/logger/logger.config.ts
@@ -2,4 +2,4 @@ import type { LogLevel } from '@nestjs/common'
 
 const defaultLogLevel: LogLevel[] = ['log', 'error', 'warn', 'debug', 'verbose', 'fatal']
 
-export const logLevel = (process.env.API_LOGGER_LEVELS?.split(',') as LogLevel[]) || defaultLogLevel
+export const logLevel = (process.env.APP_LOGGER_LEVELS?.split(',') as LogLevel[]) || defaultLogLevel


### PR DESCRIPTION
## Summary
- Update `config.command.ts` to use `ConsoleService`
- Update `generate-secret.command.ts` to use `ConsoleService`
- Fix `logger.config.ts` to use `APP_LOGGER_LEVELS` (consistent with `ConsoleService`)
- Update all related tests with `ConsoleService` mocks

## Changes
- `src/cli/commands/config.command.ts` - Use ConsoleService.success()
- `src/cli/commands/generate-secret.command.ts` - Use ConsoleService.success()
- `src/config/logger/logger.config.ts` - API_LOGGER_LEVELS → APP_LOGGER_LEVELS
- `src/config/logger/logger.config.spec.ts` - Update tests for new env var
- `src/cli/commands/config.command.spec.ts` - Add ConsoleService mock
- `src/cli/commands/generate-secret.command.spec.ts` - Replace consoleSpy with ConsoleService mock

## Testing
- 128 tests passing
- Build passing
- Lint passing