### PR TITLE
chore(deps): remove deprecated dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pnpm
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Remove .github/dependabot.yml - Dependabot does not support pnpm
- Already using renovate for dependency updates which supports pnpm

## Reason
Dependabot does not support pnpm as a package ecosystem. The config was causing validation errors. Renovate is already configured and handles all dependency updates.