### PR TITLE
fix(docker): use git tags for image versioning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   docker-image-build:
     name: Docker Image Build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
 
     permissions:
       contents: read
@@ -36,7 +36,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
-            type=sha,prefix=
+            type=ref,event=tag
+            type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Run workflow on both main branch and tag pushes
- Use semver pattern for version tags instead of commit SHA
- Add type=ref,event=tag for proper tag handling

## Changes

### 1. Job Condition (Line 13)
```yaml
if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
```

### 2. Metadata Tags (Lines 37-41)
```yaml
tags: |
  type=ref,event=branch
  type=ref,event=tag
  type=semver,pattern={{version}}
  type=raw,value=latest,enable={{is_default_branch}}
```

## Expected Behavior

| Event | Tags Created |
|-------|-------------|
| Push to main | latest, SHA |
| Push tag v0.1.3 | 0.1.3, v0.1.3, latest |