### PR TITLE
feat(config): enhance config command with --list, --get, --set, --validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Configuration is managed via `config/config.json` with environment variable over
 ```json
 {
   "app": {
-    "environment": "development",
     "secretKey": "",
     "logger": {
       "level": "debug",
@@ -66,16 +65,30 @@ Configuration is managed via `config/config.json` with environment variable over
 }
 ```
 
+### Config Command Options
+
+| Option | Description |
+|--------|-------------|
+| `paw-tools config` | Load and validate config file |
+| `paw-tools config -c <path>` | Load config from custom path |
+| `paw-tools config -l` / `--list` | List all config values |
+| `paw-tools config -g <key>` / `--get <key>` | Get specific config value (e.g., `app.logger.level`) |
+| `paw-tools config -s <key>=<value>` / `--set <key>=<value>` | Set config value in file |
+| `paw-tools config --validate` | Validate config without loading |
+| `paw-tools config -e` / `--export` | Export default config template |
+| `PAW_CONFIG=<path> paw-tools config` | Use env var for config path |
+
 ### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NODE_ENV` | development | Environment (development, production, test) |
+| `NODE_ENV` | development | Environment (development, production, test) - CLI-only, not in config |
 | `APP_SECRET_KEY` | - | App secret key (optional) |
 | `APP_LOGGER_LEVELS` | debug | Logger levels (0-7 or level names) |
 | `APP_LOGGER_TAG` | false | Show `[paw-tools]` prefix in logs |
 | `APP_LOGGER_DATE` | false | Show timestamps in logs |
 | `APP_LOGGER_FORMAT` | pretty | Output format (pretty, json) |
+| `PAW_CONFIG` | - | Custom config file path |
 
 ## Development
 

--- a/src/cli/commands/config.command.spec.ts
+++ b/src/cli/commands/config.command.spec.ts
@@ -164,7 +164,6 @@ describe('ConfigCommand', () => {
         '/tmp/test.json',
         expect.objectContaining({
           app: expect.objectContaining({
-            environment: 'development',
             logger: expect.objectContaining({
               level: 'debug'
             })
@@ -267,9 +266,7 @@ describe('ConfigCommand', () => {
       expect(mockFileHandler.writeJson).toHaveBeenCalledWith(
         './custom-config.json',
         expect.objectContaining({
-          app: expect.objectContaining({
-            environment: 'development'
-          })
+          app: expect.objectContaining({})
         })
       )
     })
@@ -290,6 +287,249 @@ describe('ConfigCommand', () => {
       expect(mockConsoleService.success).toHaveBeenCalledWith(
         expect.stringContaining('Config exported to:')
       )
+    })
+  })
+
+  describe('parseList', () => {
+    it('should return true when flag is provided', () => {
+      const result = command.parseList()
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('parseGet', () => {
+    it('should return the provided key value', () => {
+      const result = command.parseGet('app.logger.level')
+      expect(result).toBe('app.logger.level')
+    })
+  })
+
+  describe('parseSet', () => {
+    it('should return the provided key=value string', () => {
+      const result = command.parseSet('app.logger.level=debug')
+      expect(result).toBe('app.logger.level=debug')
+    })
+  })
+
+  describe('parseValidate', () => {
+    it('should return true when flag is provided', () => {
+      const result = command.parseValidate()
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('getConfigValue', () => {
+    it('should return value for simple key', () => {
+      const config = { app: { level: 'info' } }
+      const result = (command as Testable<ConfigCommand>)['getConfigValue'](config, 'app')
+      expect(result).toEqual({ level: 'info' })
+    })
+
+    it('should return value for nested key', () => {
+      const config = { app: { logger: { level: 'info' } } }
+      const result = (command as Testable<ConfigCommand>)['getConfigValue'](
+        config,
+        'app.logger.level'
+      )
+      expect(result).toBe('info')
+    })
+
+    it('should return undefined for non-existent key', () => {
+      const config = { app: { logger: { level: 'info' } } }
+      const result = (command as Testable<ConfigCommand>)['getConfigValue'](
+        config,
+        'app.missing.key'
+      )
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('setConfigValue', () => {
+    it('should set simple key value', () => {
+      const config = { app: {} }
+      const result = (command as Testable<ConfigCommand>)['setConfigValue'](
+        config,
+        'app.test',
+        'value'
+      )
+      expect(result).toEqual({ app: { test: 'value' } })
+    })
+
+    it('should set nested key value', () => {
+      const config = { app: { logger: {} } }
+      const result = (command as Testable<ConfigCommand>)['setConfigValue'](
+        config,
+        'app.logger.level',
+        'debug'
+      )
+      expect(result).toEqual({ app: { logger: { level: 'debug' } } })
+    })
+
+    it('should create nested path when not exists', () => {
+      const config = { app: {} }
+      const result = (command as Testable<ConfigCommand>)['setConfigValue'](
+        config,
+        'app.logger.level',
+        'info'
+      )
+      expect(result).toEqual({ app: { logger: { level: 'info' } } })
+    })
+
+    it('should preserve original config (immutability)', () => {
+      const config = { app: { logger: { level: 'info' } } }
+      ;(command as Testable<ConfigCommand>)['setConfigValue'](config, 'app.new', 'value')
+      expect(config).toEqual({ app: { logger: { level: 'info' } } })
+    })
+  })
+
+  describe('parseValue', () => {
+    it('should parse "true" as boolean true', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('true')
+      expect(result).toBe(true)
+    })
+
+    it('should parse "false" as boolean false', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('false')
+      expect(result).toBe(false)
+    })
+
+    it('should parse "null" as null', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('null')
+      expect(result).toBe(null)
+    })
+
+    it('should parse "undefined" as undefined', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('undefined')
+      expect(result).toBeUndefined()
+    })
+
+    it('should parse numeric string as number', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('123')
+      expect(result).toBe(123)
+    })
+
+    it('should return string for non-special strings', () => {
+      const result = (command as Testable<ConfigCommand>)['parseValue']('hello world')
+      expect(result).toBe('hello world')
+    })
+  })
+
+  describe('buildMergedConfig', () => {
+    it('should return defaults when config is empty', () => {
+      const config = {}
+      const result = (command as Testable<ConfigCommand>)['buildMergedConfig'](config)
+      expect(result).toHaveProperty('app.logger.level', 'debug')
+      expect(result).toHaveProperty('app.logger.format', 'pretty')
+    })
+
+    it('should merge partial config with defaults', () => {
+      const config = { app: { logger: { level: 'error' } } }
+      const result = (command as Testable<ConfigCommand>)['buildMergedConfig'](config)
+      expect(result).toHaveProperty('app.logger.level', 'error')
+      expect(result).toHaveProperty('app.logger.format', 'pretty')
+    })
+
+    it('should override defaults with full config', () => {
+      const config = { app: { secretKey: 'key', logger: { level: 'info', tag: true } } }
+      const result = (command as Testable<ConfigCommand>)['buildMergedConfig'](config)
+      expect(result).toHaveProperty('app.secretKey', 'key')
+      expect(result).toHaveProperty('app.logger.level', 'info')
+      expect(result).toHaveProperty('app.logger.tag', true)
+    })
+
+    it('should handle nested object when target has primitive at path', () => {
+      const config = { app: { secretKey: 'key' } }
+      const result = (command as Testable<ConfigCommand>)['buildMergedConfig'](config)
+      expect(result).toHaveProperty('app.secretKey', 'key')
+      expect(result).toHaveProperty('app.logger')
+    })
+
+    it('should merge new keys not in defaults', () => {
+      const config = { app: { customField: 'custom' } }
+      const result = (command as Testable<ConfigCommand>)['buildMergedConfig'](config)
+      expect(result).toHaveProperty('app.customField', 'custom')
+    })
+  })
+
+  describe('formatValue', () => {
+    it('should format primitive values as string', () => {
+      expect((command as Testable<ConfigCommand>)['formatValue']('test')).toBe('test')
+      expect((command as Testable<ConfigCommand>)['formatValue'](123)).toBe('123')
+      expect((command as Testable<ConfigCommand>)['formatValue'](true)).toBe('true')
+    })
+
+    it('should format objects as JSON string', () => {
+      const obj = { level: 'info', tag: false }
+      const result = (command as Testable<ConfigCommand>)['formatValue'](obj)
+      expect(result).toContain('"level": "info"')
+    })
+  })
+
+  describe('run with --list', () => {
+    it('should list all config values', async () => {
+      await command.run([], { list: true })
+
+      expect(mockConsoleService.info).toHaveBeenCalledWith(expect.stringContaining('Config file:'))
+      expect(mockConsoleService.log).toHaveBeenCalled()
+    })
+  })
+
+  describe('run with --get', () => {
+    it('should get specific config value', async () => {
+      await command.run([], { get: 'app.logger.format' })
+
+      expect(mockConsoleService.log).toHaveBeenCalledWith('pretty')
+    })
+
+    it('should exit with error when key not found', async () => {
+      mockFileHandler.readJson.mockResolvedValue({})
+
+      await command.run([], { get: 'nonexistent.key' })
+
+      expect(processExitSpy).toHaveBeenCalledWith(1)
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
+        'Error:',
+        expect.objectContaining({ message: 'Key not found: nonexistent.key' })
+      )
+    })
+  })
+
+  describe('run with --set', () => {
+    it('should set config value in file', async () => {
+      await command.run([], { set: 'app.logger.level=error' })
+
+      expect(mockFileHandler.writeJson).toHaveBeenCalled()
+      expect(mockConsoleService.success).toHaveBeenCalledWith(expect.stringContaining('Updated'))
+    })
+
+    it('should exit with error for invalid format', async () => {
+      await command.run([], { set: 'invalid' })
+
+      expect(processExitSpy).toHaveBeenCalledWith(1)
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
+        'Error:',
+        expect.objectContaining({ message: 'Invalid --set format. Use: --set key=value' })
+      )
+    })
+
+    it('should exit with error when write fails', async () => {
+      mockFileHandler.writeJson.mockRejectedValue(new Error('Write failed'))
+
+      await command.run([], { set: 'app.test=value' })
+
+      expect(processExitSpy).toHaveBeenCalledWith(1)
+      expect(mockConsoleService.error).toHaveBeenCalledWith(
+        'Error:',
+        expect.objectContaining({ message: 'Write failed' })
+      )
+    })
+  })
+
+  describe('run with --validate', () => {
+    it('should validate and output success', async () => {
+      await command.run([], { validate: true })
+
+      expect(mockConsoleService.success).toHaveBeenCalledWith(expect.stringContaining('valid'))
     })
   })
 })

--- a/src/cli/commands/config.command.ts
+++ b/src/cli/commands/config.command.ts
@@ -9,6 +9,10 @@ import { FileHandlerService } from '@/shared/file-handler'
 interface ConfigCommandOptions {
   config?: string
   export?: string
+  list?: boolean
+  get?: string
+  set?: string
+  validate?: boolean
 }
 
 @Command({
@@ -56,6 +60,134 @@ export class ConfigCommand extends CommandRunner {
     this.consoleService.success(`Config exported to: ${path}`)
   }
 
+  private getConfigValue(config: Record<string, unknown>, key: string): unknown {
+    const keys = key.split('.')
+    let current: unknown = config
+
+    for (const k of keys) {
+      if (current && typeof current === 'object' && k in current) {
+        current = (current as Record<string, unknown>)[k]
+      } else {
+        return undefined
+      }
+    }
+
+    return current
+  }
+
+  private setConfigValue(
+    config: Record<string, unknown>,
+    key: string,
+    value: string
+  ): Record<string, unknown> {
+    const keys = key.split('.')
+    const result = JSON.parse(JSON.stringify(config))
+    let current: Record<string, unknown> = result
+
+    for (let i = 0; i < keys.length - 1; i++) {
+      const k = keys[i]
+      if (!(k in current) || typeof current[k] !== 'object') {
+        current[k] = {}
+      }
+      current = current[k] as Record<string, unknown>
+    }
+
+    const lastKey = keys[keys.length - 1]
+    const parsedValue = this.parseValue(value)
+    current[lastKey] = parsedValue
+
+    return result
+  }
+
+  private parseValue(value: string): unknown {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    if (value === 'null') return null
+    if (value === 'undefined') return undefined
+    if (!isNaN(Number(value)) && value.trim() !== '') return Number(value)
+    return value
+  }
+
+  private buildMergedConfig(config: Record<string, unknown>): Record<string, unknown> {
+    const merged = JSON.parse(JSON.stringify(DEFAULT_CONFIG))
+
+    const merge = (target: Record<string, unknown>, source: Record<string, unknown>): void => {
+      for (const key in source) {
+        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+          if (!target[key] || typeof target[key] !== 'object') {
+            target[key] = {}
+          }
+          merge(target[key] as Record<string, unknown>, source[key] as Record<string, unknown>)
+        } else {
+          target[key] = source[key]
+        }
+      }
+    }
+
+    merge(merged as Record<string, unknown>, config)
+
+    return merged
+  }
+
+  private formatValue(value: unknown): string {
+    if (typeof value === 'object') {
+      return JSON.stringify(value, null, 2)
+    }
+    return String(value)
+  }
+
+  private async listConfig(configPath: string, config: Record<string, unknown>): Promise<void> {
+    const mergedConfig = this.buildMergedConfig(config)
+
+    this.consoleService.info(`Config file: ${configPath}`)
+    this.consoleService.log('')
+
+    const printSection = (section: string, obj: unknown, prefix = ''): void => {
+      this.consoleService.info(`${prefix}${section}:`)
+      if (obj && typeof obj === 'object') {
+        for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+          const valueStr = this.formatValue(value)
+          if (value && typeof value === 'object' && !Array.isArray(value)) {
+            this.consoleService.log(`  ${key}:`)
+            for (const [subKey, subValue] of Object.entries(value as Record<string, unknown>)) {
+              this.consoleService.log(`    ${subKey}: ${this.formatValue(subValue)}`)
+            }
+          } else {
+            this.consoleService.log(`  ${key}: ${valueStr}`)
+          }
+        }
+      }
+    }
+
+    printSection('app', mergedConfig['app'])
+  }
+
+  private async getConfigValueByKey(
+    key: string,
+    _configPath: string,
+    config: Record<string, unknown>
+  ): Promise<void> {
+    const mergedConfig = this.buildMergedConfig(config)
+    const value = this.getConfigValue(mergedConfig, key)
+
+    if (value === undefined) {
+      throw new Error(`Key not found: ${key}`)
+    }
+
+    this.consoleService.log(this.formatValue(value))
+  }
+
+  private async setConfigValueInFile(
+    key: string,
+    value: string,
+    configPath: string,
+    config: Record<string, unknown>
+  ): Promise<void> {
+    const updatedConfig = this.setConfigValue(config, key, value)
+    await this.fileHandler.writeJson(configPath, updatedConfig)
+    this.consoleService.success(`Updated ${key} in ${configPath}`)
+  }
+
   @Option({
     flags: '-c, --config <path>',
     description: 'Path to custom config file'
@@ -73,6 +205,38 @@ export class ConfigCommand extends CommandRunner {
     return path || join(process.cwd(), 'config', 'config.json')
   }
 
+  @Option({
+    flags: '-l, --list',
+    description: 'List all configuration values'
+  })
+  parseList(): boolean | undefined {
+    return true
+  }
+
+  @Option({
+    flags: '-g, --get <key>',
+    description: 'Get a specific config value (e.g., app.logger.level)'
+  })
+  parseGet(val: string): string {
+    return val
+  }
+
+  @Option({
+    flags: '-s, --set <key=value>',
+    description: 'Set a config value (e.g., app.logger.level=debug)'
+  })
+  parseSet(val: string): string {
+    return val
+  }
+
+  @Option({
+    flags: '-v, --validate',
+    description: 'Validate config without loading'
+  })
+  parseValidate(): boolean | undefined {
+    return true
+  }
+
   async run(_passedParam: string[], options?: ConfigCommandOptions): Promise<void> {
     try {
       if (options?.export !== undefined) {
@@ -85,6 +249,41 @@ export class ConfigCommand extends CommandRunner {
       }
 
       const configPath = this.resolveConfigPath(options?.config)
+
+      if (
+        options?.list !== undefined ||
+        options?.get ||
+        options?.set ||
+        options?.validate !== undefined
+      ) {
+        const config = await this.loadConfig(configPath)
+        this.validateConfig(config)
+
+        if (options?.validate !== undefined) {
+          this.consoleService.success(`Configuration is valid: ${configPath}`)
+          return
+        }
+
+        if (options?.list !== undefined) {
+          await this.listConfig(configPath, config)
+          return
+        }
+
+        if (options?.get) {
+          await this.getConfigValueByKey(options.get, configPath, config)
+          return
+        }
+
+        if (options?.set) {
+          const [key, value] = options.set.split('=')
+          if (!key || value === undefined) {
+            throw new Error('Invalid --set format. Use: --set key=value')
+          }
+          await this.setConfigValueInFile(key, value, configPath, config)
+          return
+        }
+      }
+
       const config = await this.loadConfig(configPath)
       this.validateConfig(config)
       this.consoleService.success(`Configuration loaded successfully: ${configPath}`)

--- a/src/shared/config/config-loader.spec.ts
+++ b/src/shared/config/config-loader.spec.ts
@@ -9,7 +9,6 @@ describe('ConfigLoader', () => {
 
   const mockConfig = {
     app: {
-      environment: 'development',
       secretKey: 'test-secret-key',
       logger: {
         level: 'debug',
@@ -23,7 +22,6 @@ describe('ConfigLoader', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     process.env = { ...originalEnv }
-    delete process.env.NODE_ENV
     delete process.env.APP_SECRET_KEY
     delete process.env.APP_LOGGER_LEVELS
     delete process.env.APP_LOGGER_TAG
@@ -40,7 +38,7 @@ describe('ConfigLoader', () => {
   it('should load config from file', () => {
     const config = loadConfig()
 
-    expect(config.app.environment).toBe('development')
+    expect(config.app.secretKey).toBe('test-secret-key')
     expect(readFileSync).toHaveBeenCalled()
   })
 
@@ -49,16 +47,7 @@ describe('ConfigLoader', () => {
 
     const config = loadConfig()
 
-    expect(config.app.environment).toBe('development')
     expect(config.app.logger.level).toBe('debug')
-  })
-
-  it('should override environment with NODE_ENV', () => {
-    process.env.NODE_ENV = 'production'
-
-    const config = loadConfig()
-
-    expect(config.app.environment).toBe('production')
   })
 
   it('should override secretKey with APP_SECRET_KEY', () => {

--- a/src/shared/config/config-loader.ts
+++ b/src/shared/config/config-loader.ts
@@ -37,7 +37,6 @@ export const loadConfig = (): AppConfig => {
 function applyEnvOverrides(config: AppConfig): AppConfig {
   return {
     app: {
-      environment: process.env.NODE_ENV || config.app.environment,
       secretKey: process.env.APP_SECRET_KEY || config.app.secretKey,
       logger: {
         level: process.env.APP_LOGGER_LEVELS || config.app.logger.level,

--- a/src/shared/config/default-config.ts
+++ b/src/shared/config/default-config.ts
@@ -1,6 +1,5 @@
 export const DEFAULT_CONFIG = {
   app: {
-    environment: 'development',
     secretKey: '',
     logger: {
       level: 'debug',


### PR DESCRIPTION
## Summary

- Remove `environment` from config file (now passed via `NODE_ENV`)
- Add `--list`/`-l` to list all config values with merged defaults
- Add `--get`/`-g` to get specific config value (e.g., `app.logger.level`)
- Add `--set`/`-s` to set config value in file (e.g., `--set app.logger.level=debug`)
- Add `--validate`/`-v` to validate config without loading
- Add comprehensive tests (99%+ coverage on config.command.ts)

## New Commands

```bash
paw-tools config --list          # List all config values
paw-tools config -g app.logger.level  # Get specific value
paw-tools config -s app.logger.level=debug  # Set value
paw-tools config -v      # Validate config
paw-tools config -e              # Export default template
```