### PR TITLE
feat(cli): add dependency checker with doctor command

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -27,6 +27,16 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["src/shared/dependency/**/*.ts"],
+      "linter": {
+        "rules": {
+          "recommended": false
+        }
+      }
+    }
+  ],
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 4.0.4(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.16
-        version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types':
         specifier: 2.1.1
         version: 2.1.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
@@ -49,7 +49,7 @@ importers:
         version: 18.1.2
       nest-commander:
         specifier: ^3.3.0
-        version: 3.20.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@types/inquirer@8.2.12)(@types/node@25.5.2)(typescript@6.0.2)
+        version: 3.20.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@types/inquirer@8.2.12)(@types/node@25.5.2)(typescript@6.0.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -74,7 +74,7 @@ importers:
         version: 11.0.10(chokidar@4.0.3)(typescript@6.0.2)
       '@nestjs/testing':
         specifier: ^11.1.16
-        version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+        version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/platform-express@11.1.19)
       '@swc/cli':
         specifier: ^0.8.0
         version: 0.8.1(@swc/core@1.15.24)(chokidar@4.0.3)
@@ -959,6 +959,12 @@ packages:
       class-validator:
         optional: true
 
+  '@nestjs/platform-express@11.1.19':
+    resolution: {integrity: sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+
   '@nestjs/schematics@11.0.10':
     resolution: {integrity: sha512-q9lr0wGwgBHLarD4uno3XiW4JX60WPlg2VTgbqPHl/6bT4u1IEEzj+q9Tad3bVnqL5mlDF3vrZ2tj+x13CJpmw==}
     peerDependencies:
@@ -1410,6 +1416,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -1494,6 +1504,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   arch@3.0.0:
     resolution: {integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==}
 
@@ -1576,6 +1589,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -1601,9 +1618,17 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   byte-counter@0.1.0:
     resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
     engines: {node: '>=20'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -1612,6 +1637,14 @@ packages:
   cacheable-request@13.0.18:
     resolution: {integrity: sha512-rFWadDRKJs3s2eYdXlGggnBZKG7MTblkFBB0YllFds+UYnfogDp2wcR6JN97FhRkHTvq59n2vhNoHNZn29dh/Q==}
     engines: {node: '>=18'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1748,6 +1781,10 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -1755,6 +1792,10 @@ packages:
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
 
   conventional-changelog-angular@8.3.1:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
@@ -1775,6 +1816,18 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -1841,6 +1894,10 @@ packages:
     resolution: {integrity: sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==}
     engines: {node: '>=16'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -1865,8 +1922,15 @@ packages:
     resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.335:
     resolution: {integrity: sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==}
@@ -1884,6 +1948,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -1899,12 +1967,27 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -1935,6 +2018,10 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -1964,6 +2051,10 @@ packages:
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -2029,6 +2120,10 @@ packages:
     resolution: {integrity: sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q==}
     engines: {node: '>=20'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2052,6 +2147,14 @@ packages:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -2066,6 +2169,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   function-timeout@1.0.2:
     resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
@@ -2083,9 +2189,17 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -2124,6 +2238,10 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   got@14.6.6:
     resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
     engines: {node: '>=20'}
@@ -2140,11 +2258,23 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
@@ -2208,6 +2338,10 @@ packages:
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -2238,6 +2372,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2567,12 +2704,28 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -2589,6 +2742,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -2619,6 +2776,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
+
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
@@ -2633,6 +2794,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -2675,6 +2840,18 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2737,6 +2914,10 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2807,12 +2988,28 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -2871,6 +3068,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -2916,6 +3117,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2923,6 +3135,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2978,6 +3206,14 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -3121,6 +3357,10 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
@@ -3189,6 +3429,17 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3229,6 +3480,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -3251,6 +3506,10 @@ packages:
   validator@13.15.26:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -3798,10 +4057,10 @@ snapshots:
       commander: 11.1.0
       prettier: 3.8.1
 
-  '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)':
     dependencies:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       lodash: 4.18.1
 
   '@hapi/address@5.1.1':
@@ -4320,7 +4579,7 @@ snapshots:
       lodash: 4.18.1
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
@@ -4331,6 +4590,8 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)
 
   '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
@@ -4339,6 +4600,19 @@ snapshots:
     optionalDependencies:
       class-transformer: 0.5.1
       class-validator: 0.15.1
+
+  '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)':
+    dependencies:
+      '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cors: 2.8.6
+      express: 5.2.1
+      multer: 2.1.1
+      path-to-regexp: 8.4.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -4362,11 +4636,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@nestjs/testing@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/platform-express@11.1.19)':
     dependencies:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)
 
   '@nuxt/opencollective@0.4.1':
     dependencies:
@@ -4819,6 +5095,12 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    optional: true
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4881,6 +5163,9 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 4.0.4
+
+  append-field@1.0.0:
+    optional: true
 
   arch@3.0.0: {}
 
@@ -4975,6 +5260,21 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -5004,7 +5304,15 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+    optional: true
+
   byte-counter@0.1.0: {}
+
+  bytes@3.1.2:
+    optional: true
 
   cacheable-lookup@7.0.0: {}
 
@@ -5017,6 +5325,18 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.1.1
       responselike: 4.0.2
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    optional: true
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    optional: true
 
   callsites@3.1.0: {}
 
@@ -5130,9 +5450,20 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+    optional: true
+
   consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
+
+  content-type@1.0.5:
+    optional: true
 
   conventional-changelog-angular@8.3.1:
     dependencies:
@@ -5150,6 +5481,18 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2:
+    optional: true
+
+  cookie@0.7.2:
+    optional: true
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    optional: true
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@25.5.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
@@ -5211,6 +5554,9 @@ snapshots:
 
   defaults@2.0.2: {}
 
+  depd@2.0.0:
+    optional: true
+
   detect-newline@3.1.0: {}
 
   diff@4.0.4: {}
@@ -5227,7 +5573,17 @@ snapshots:
 
   dotenv@17.4.1: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1:
+    optional: true
 
   electron-to-chromium@1.5.335: {}
 
@@ -5238,6 +5594,9 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0:
+    optional: true
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -5252,9 +5611,23 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1:
+    optional: true
+
+  es-errors@1.3.0:
+    optional: true
+
   es-module-lexer@2.0.0: {}
 
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+    optional: true
+
   escalade@3.2.0: {}
+
+  escape-html@1.0.3:
+    optional: true
 
   escape-string-regexp@1.0.5: {}
 
@@ -5274,6 +5647,9 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  etag@1.8.1:
+    optional: true
 
   eventemitter3@5.0.4: {}
 
@@ -5335,6 +5711,40 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   ext-list@2.2.2:
     dependencies:
       mime-db: 1.54.0
@@ -5395,6 +5805,18 @@ snapshots:
     dependencies:
       filename-reserved-regex: 4.0.0
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -5429,6 +5851,12 @@ snapshots:
 
   form-data-encoder@4.1.0: {}
 
+  forwarded@0.2.0:
+    optional: true
+
+  fresh@2.0.0:
+    optional: true
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -5442,6 +5870,9 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2:
+    optional: true
+
   function-timeout@1.0.2: {}
 
   gensync@1.0.0-beta.2: {}
@@ -5450,7 +5881,27 @@ snapshots:
 
   get-east-asian-width@1.5.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+    optional: true
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+    optional: true
 
   get-stream@6.0.1: {}
 
@@ -5499,6 +5950,9 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  gopd@1.2.0:
+    optional: true
+
   got@14.6.6:
     dependencies:
       '@sindresorhus/is': 7.2.0
@@ -5527,9 +5981,26 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0:
+    optional: true
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+    optional: true
+
   html-escaper@2.0.2: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    optional: true
 
   http2-wrapper@2.2.1:
     dependencies:
@@ -5597,6 +6068,9 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
+  ipaddr.js@1.9.1:
+    optional: true
+
   is-arrayish@0.2.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -5614,6 +6088,9 @@ snapshots:
   is-plain-obj@1.1.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0:
+    optional: true
 
   is-stream@2.0.1: {}
 
@@ -6121,11 +6598,23 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  math-intrinsics@1.1.0:
+    optional: true
+
+  media-typer@0.3.0:
+    optional: true
+
+  media-typer@1.1.0:
+    optional: true
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
 
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0:
+    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -6136,6 +6625,11 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+    optional: true
 
   mimic-fn@2.1.0: {}
 
@@ -6155,6 +6649,14 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+    optional: true
+
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
@@ -6163,14 +6665,17 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0:
+    optional: true
+
   neo-async@2.6.2: {}
 
-  nest-commander@3.20.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@types/inquirer@8.2.12)(@types/node@25.5.2)(typescript@6.0.2):
+  nest-commander@3.20.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@types/inquirer@8.2.12)(@types/node@25.5.2)(typescript@6.0.2):
     dependencies:
       '@fig/complete-commander': 3.2.0(commander@11.1.0)
-      '@golevelup/nestjs-discovery': 5.0.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@golevelup/nestjs-discovery': 5.0.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@types/inquirer': 8.2.12
       commander: 11.1.0
       cosmiconfig: 8.3.6(typescript@6.0.2)
@@ -6205,6 +6710,17 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  object-assign@4.1.1:
+    optional: true
+
+  object-inspect@1.13.4:
+    optional: true
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+    optional: true
 
   once@1.4.0:
     dependencies:
@@ -6271,6 +6787,9 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parseurl@1.3.3:
+    optional: true
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6323,9 +6842,31 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    optional: true
+
   pure-rand@7.0.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
+
   quick-lru@5.1.1: {}
+
+  range-parser@1.2.1:
+    optional: true
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    optional: true
 
   react-is@18.3.1: {}
 
@@ -6374,6 +6915,17 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   run-async@2.4.1: {}
 
   rxjs@7.8.1:
@@ -6415,11 +6967,73 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  setprototypeof@1.2.0:
+    optional: true
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    optional: true
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    optional: true
 
   signal-exit@3.0.7: {}
 
@@ -6468,6 +7082,12 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.2:
+    optional: true
+
+  streamsearch@1.1.0:
+    optional: true
 
   streamx@2.25.0:
     dependencies:
@@ -6616,6 +7236,9 @@ snapshots:
 
   tmpl@1.0.5: {}
 
+  toidentifier@1.0.1:
+    optional: true
+
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
@@ -6683,6 +7306,22 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    optional: true
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    optional: true
+
+  typedarray@0.0.6:
+    optional: true
+
   typescript@5.9.3: {}
 
   typescript@6.0.2: {}
@@ -6708,6 +7347,9 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0:
+    optional: true
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -6750,6 +7392,9 @@ snapshots:
       convert-source-map: 2.0.0
 
   validator@13.15.26: {}
+
+  vary@1.1.2:
+    optional: true
 
   walker@1.0.8:
     dependencies:

--- a/src/cli/cli.module.ts
+++ b/src/cli/cli.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common'
 
-import { ConfigCommand, GenerateSecretCommand, InitProjectCommand } from './commands'
+import { ConfigCommand, DoctorCommand, GenerateSecretCommand, InitProjectCommand } from './commands'
 
 @Module({
-  providers: [ConfigCommand, GenerateSecretCommand, InitProjectCommand]
+  providers: [ConfigCommand, DoctorCommand, GenerateSecretCommand, InitProjectCommand]
 })
 export class CliModule {}

--- a/src/cli/commands/doctor.command.spec.ts
+++ b/src/cli/commands/doctor.command.spec.ts
@@ -1,0 +1,145 @@
+import { CommandRunner } from 'nest-commander'
+import { ConsoleService } from '@/shared/console'
+import { DependencyService } from '@/shared/dependency'
+import { ExitCodes } from '@/shared/exit-codes'
+import { ProcessService } from '@/shared/process'
+import { DoctorCommand } from './doctor.command'
+
+// Mock the dependencies
+jest.mock('@/shared/console', () => ({
+  ConsoleService: jest.fn().mockImplementation(() => ({
+    info: jest.fn(),
+    success: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+    fail: jest.fn(),
+    debug: jest.fn()
+  }))
+}))
+
+jest.mock('@/shared/dependency', () => ({
+  DependencyService: jest.fn().mockImplementation(() => ({
+    check: jest.fn(),
+    which: jest.fn()
+  }))
+}))
+
+jest.mock('@/shared/process', () => ({
+  ProcessService: jest.fn()
+}))
+
+// Mock process.exit to be a no-op
+jest.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+
+describe('DoctorCommand', () => {
+  let command: DoctorCommand
+  let consoleService: jest.Mocked<ConsoleService>
+  let dependencyService: jest.Mocked<DependencyService>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    command = new DoctorCommand()
+
+    consoleService = (ConsoleService as jest.Mock).mock.results[0].value
+    dependencyService = (DependencyService as jest.Mock).mock.results[0].value
+  })
+
+  it('should be defined', () => {
+    expect(command).toBeDefined()
+  })
+
+  it('should extend CommandRunner', () => {
+    expect(command).toBeInstanceOf(CommandRunner)
+  })
+
+  describe('run', () => {
+    it('should check dependencies and display results', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [],
+        warnings: []
+      })
+
+      await command.run([], {})
+
+      expect(dependencyService.check).toHaveBeenCalled()
+      expect(consoleService.info).toHaveBeenCalledWith(
+        expect.stringContaining('Required Dependencies')
+      )
+    })
+
+    it('should show missing dependencies', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [
+          {
+            name: 'git',
+            requiredVersion: '>=2.30',
+            installedVersion: null,
+            installedPath: null,
+            isMet: false
+          }
+        ],
+        warnings: []
+      })
+
+      await command.run([], {})
+
+      expect(process.exit).toHaveBeenCalledWith(ExitCodes.ERROR)
+      expect(consoleService.info).toHaveBeenCalledWith(expect.stringContaining('git'))
+    })
+
+    it('should show warnings for version mismatches', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [],
+        warnings: [
+          {
+            name: 'docker',
+            installedVersion: '20.0',
+            requiredVersion: '>=24.0',
+            installedPath: '/usr/bin/docker'
+          }
+        ]
+      })
+
+      await command.run([], {})
+
+      expect(consoleService.info).toHaveBeenCalledWith(expect.stringContaining('docker'))
+    })
+
+    it('should show optional dependencies in verbose mode', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [],
+        warnings: []
+      })
+      dependencyService.which.mockReturnValue('/usr/bin/docker')
+
+      await command.run([], { verbose: true })
+
+      expect(dependencyService.which).toHaveBeenCalledWith('docker')
+    })
+
+    it('should handle missing optional dependencies in verbose mode', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [],
+        warnings: []
+      })
+      dependencyService.which.mockReturnValue(null)
+
+      await command.run([], { verbose: true })
+
+      expect(consoleService.info).toHaveBeenCalled()
+    })
+
+    it('should display success when all dependencies are met', async () => {
+      dependencyService.check.mockResolvedValue({
+        missing: [],
+        warnings: []
+      })
+
+      await command.run([], {})
+
+      expect(consoleService.success).toHaveBeenCalledWith(expect.stringContaining('OK'))
+    })
+  })
+})

--- a/src/cli/commands/doctor.command.ts
+++ b/src/cli/commands/doctor.command.ts
@@ -1,0 +1,190 @@
+import { Command, CommandRunner, Option } from 'nest-commander'
+
+import {
+  OPTIONAL_DEPENDENCIES,
+  REQUIRED_DEPENDENCIES
+} from '@/config/constants/dependencies.constants'
+import { ConsoleService } from '@/shared/console'
+import { DependencyService } from '@/shared/dependency'
+import { ExitCodes } from '@/shared/exit-codes'
+import { ProcessService } from '@/shared/process'
+
+interface DoctorOptions {
+  verbose?: boolean
+}
+
+@Command({
+  name: 'doctor',
+  description: 'Check dependency health'
+})
+export class DoctorCommand extends CommandRunner {
+  private readonly consoleService: ConsoleService
+  private readonly dependencyService: DependencyService
+
+  constructor() {
+    super()
+    this.consoleService = new ConsoleService()
+    this.dependencyService = new DependencyService(new ProcessService())
+  }
+
+  private getStatusIcon(isInstalled: boolean, hasWarning: boolean): string {
+    if (!isInstalled) return '✗'
+    if (hasWarning) return '⚠'
+    return '✓'
+  }
+
+  private formatDependency(
+    dep: { name: string; version?: string; description?: string },
+    installedVersion: string | null,
+    requiredVersion: string | null,
+    isInstalled: boolean,
+    hasWarning: boolean,
+    verbose: boolean
+  ): void {
+    const icon = this.getStatusIcon(isInstalled, hasWarning)
+    const versionInfo = requiredVersion ? ` (${requiredVersion})` : ''
+    const installedInfo = installedVersion ? ` ${installedVersion}` : ''
+
+    this.consoleService.info(`  ${icon} ${dep.name}${installedInfo}${versionInfo}`)
+
+    if (verbose) {
+      if (dep.description) {
+        this.consoleService.log(`    Description: ${dep.description}`)
+      }
+      if (!isInstalled) {
+        this.consoleService.warn(`    Status: not installed`)
+      }
+    }
+  }
+
+  @Option({
+    flags: '-v, --verbose',
+    description: 'Show detailed information'
+  })
+  parseVerbose(): boolean {
+    return true
+  }
+
+  async run(_params: string[], options?: DoctorOptions): Promise<void> {
+    this.consoleService.info('Checking dependencies...\n')
+
+    const requiredResult = await this.dependencyService.check(REQUIRED_DEPENDENCIES)
+    const optionalResult = await this.dependencyService.check(OPTIONAL_DEPENDENCIES)
+
+    // Required Dependencies
+    this.consoleService.info('Required Dependencies:')
+    for (const dep of REQUIRED_DEPENDENCIES) {
+      const missing = requiredResult.missing.find((m) => m.name === dep.name)
+      const warning = requiredResult.warnings.find((w) => w.name === dep.name)
+
+      if (missing) {
+        this.formatDependency(
+          dep,
+          null,
+          missing.requiredVersion,
+          false,
+          false,
+          options?.verbose ?? false
+        )
+      } else if (warning) {
+        this.formatDependency(
+          dep,
+          warning.installedVersion,
+          warning.requiredVersion,
+          true,
+          true,
+          options?.verbose ?? false
+        )
+        if (options?.verbose) {
+          this.consoleService.warn(`    Path: ${warning.installedPath}`)
+          this.consoleService.warn(`    Status: Some features may be limited`)
+        }
+      } else {
+        this.formatDependency(
+          dep,
+          null,
+          dep.version || null,
+          true,
+          false,
+          options?.verbose ?? false
+        )
+        const installedPath = this.dependencyService.which(dep.name)
+        if (options?.verbose && installedPath) {
+          this.consoleService.log(`    Path: ${installedPath}`)
+        }
+      }
+    }
+
+    // Optional Dependencies
+    this.consoleService.info('\nOptional Dependencies:')
+    let hasOptionalShown = false
+
+    for (const dep of OPTIONAL_DEPENDENCIES) {
+      const missing = optionalResult.missing.find((m) => m.name === dep.name)
+      const warning = optionalResult.warnings.find((w) => w.name === dep.name)
+
+      if (missing) {
+        if (options?.verbose) {
+          this.formatDependency(dep, null, missing.requiredVersion, false, false, true)
+          hasOptionalShown = true
+        }
+      } else if (warning) {
+        this.formatDependency(
+          dep,
+          warning.installedVersion,
+          warning.requiredVersion,
+          true,
+          true,
+          options?.verbose ?? false
+        )
+        if (options?.verbose) {
+          this.consoleService.warn(`    Path: ${warning.installedPath}`)
+          this.consoleService.warn(`    Status: Some features may be limited`)
+        }
+        hasOptionalShown = true
+      } else {
+        const installedPath = this.dependencyService.which(dep.name)
+        if (installedPath) {
+          this.formatDependency(
+            dep,
+            null,
+            dep.version || null,
+            true,
+            false,
+            options?.verbose ?? false
+          )
+          if (options?.verbose) {
+            this.consoleService.log(`    Path: ${installedPath}`)
+          }
+          hasOptionalShown = true
+        } else if (options?.verbose) {
+          // Show as not installed in verbose mode
+          this.formatDependency(dep, null, dep.version || null, false, false, true)
+          hasOptionalShown = true
+        }
+      }
+    }
+
+    if (!hasOptionalShown && OPTIONAL_DEPENDENCIES.length > 0) {
+      this.consoleService.info('  (none installed)')
+    }
+
+    // Summary
+    const totalWarnings = requiredResult.warnings.length + optionalResult.warnings.length
+    const hasRequiredMissing = requiredResult.missing.length > 0
+
+    this.consoleService.info('')
+    if (hasRequiredMissing) {
+      this.consoleService.fail('Dependency Health: FAILED')
+      process.exit(ExitCodes.ERROR)
+    }
+
+    if (totalWarnings > 0) {
+      this.consoleService.warn(
+        `Dependency Health: OK (${totalWarnings} warning${totalWarnings > 1 ? 's' : ''})`
+      )
+    } else {
+      this.consoleService.success('Dependency Health: OK')
+    }
+  }
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,3 +1,4 @@
 export * from './config.command'
+export * from './doctor.command'
 export * from './generate-secret.command'
 export * from './init-project.command'

--- a/src/config/constants/dependencies.constants.ts
+++ b/src/config/constants/dependencies.constants.ts
@@ -1,0 +1,20 @@
+import type { Dependency } from '@/shared/dependency'
+
+export const REQUIRED_DEPENDENCIES: Dependency[] = [
+  {
+    name: 'git',
+    version: '>=2.30',
+    description: 'Version control operations'
+  }
+]
+
+export const OPTIONAL_DEPENDENCIES: Dependency[] = [
+  {
+    name: 'docker',
+    version: '>=24.0',
+    isRequired: false,
+    description: 'Containerized builds and deployments'
+  }
+]
+
+export const ALL_DEPENDENCIES = [...REQUIRED_DEPENDENCIES, ...OPTIONAL_DEPENDENCIES]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,63 @@
+import { NestFactory } from '@nestjs/core'
 import { CommandFactory } from 'nest-commander'
 
 import { AppModule } from './app.module'
+import { REQUIRED_DEPENDENCIES } from './config/constants/dependencies.constants'
+import { ConsoleService } from './shared/console'
+import { DependencyService } from './shared/dependency'
+import { ExitCodes } from './shared/exit-codes'
+
+async function checkDependencies(): Promise<boolean> {
+  const args = process.argv.slice(2)
+
+  // Skip dependency check for --help, --version
+  if (
+    args.includes('--help') ||
+    args.includes('--version') ||
+    args.includes('-h') ||
+    args.includes('-v')
+  ) {
+    return false
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule)
+  const dependencyService = app.get(DependencyService)
+  const consoleService = app.get(ConsoleService)
+
+  consoleService.debug('Checking required dependencies...')
+
+  const { missing, warnings } = await dependencyService.check(REQUIRED_DEPENDENCIES)
+
+  if (missing.length > 0) {
+    consoleService.error('Missing dependencies:')
+    for (const dep of missing) {
+      const version = dep.requiredVersion ? ` (required: ${dep.requiredVersion})` : ''
+      consoleService.error(`  - ${dep.name}${version}`)
+    }
+    await app.close()
+    return true
+  }
+
+  if (warnings.length > 0) {
+    consoleService.warn('Dependency warnings:')
+    for (const warning of warnings) {
+      consoleService.warn(
+        `  - ${warning.name}: ${warning.installedVersion} found, ${warning.requiredVersion} recommended`
+      )
+    }
+  }
+
+  consoleService.debug('All required dependencies are installed')
+  await app.close()
+  return false
+}
 
 async function bootstrap(): Promise<void> {
+  const hasMissingDeps = await checkDependencies()
+  if (hasMissingDeps) {
+    process.exit(ExitCodes.ERROR)
+  }
+
   await CommandFactory.run(AppModule)
 }
 

--- a/src/shared/dependency/dependency.module.ts
+++ b/src/shared/dependency/dependency.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+
+import { ProcessModule } from '@/shared/process'
+import { DependencyService } from './dependency.service'
+
+@Module({
+  imports: [ProcessModule],
+  providers: [DependencyService],
+  exports: [DependencyService]
+})
+export class DependencyModule {}

--- a/src/shared/dependency/dependency.service.spec.ts
+++ b/src/shared/dependency/dependency.service.spec.ts
@@ -1,0 +1,60 @@
+import { ProcessService } from '../process/process.service'
+import { DependencyService } from './dependency.service'
+
+describe('DependencyService', () => {
+  const service = new DependencyService(new ProcessService())
+
+  describe('check', () => {
+    it('should return empty missing and warnings when git is installed', async () => {
+      const result = await service.check([{ name: 'git' }])
+
+      expect(result.missing).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    it('should return missing when command not found', async () => {
+      const result = await service.check([{ name: 'nonexistent-xyz-12345' }])
+
+      expect(result.missing).toHaveLength(1)
+      expect(result.missing[0].name).toBe('nonexistent-xyz-12345')
+    })
+
+    it('should check version constraint >=', async () => {
+      const result = await service.check([{ name: 'git', version: '>=2.0' }])
+
+      expect(result.missing).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    it('should return warning when version requirement not met', async () => {
+      const result = await service.check([{ name: 'git', version: '>=99.0' }])
+
+      expect(result.missing).toHaveLength(0)
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].name).toBe('git')
+    })
+
+    it('should check caret ^ version', async () => {
+      const result = await service.check([{ name: 'git', version: '^2.0' }])
+
+      expect(result.missing).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    it('should handle multiple dependencies', async () => {
+      const result = await service.check([{ name: 'git' }, { name: 'nonexistent-xyz-12345' }])
+
+      expect(result.missing).toHaveLength(1)
+      expect(result.missing[0].name).toBe('nonexistent-xyz-12345')
+    })
+
+    it('should skip optional dependencies that are not installed', async () => {
+      const result = await service.check([
+        { name: 'git' },
+        { name: 'nonexistent-xyz-12345', isRequired: false }
+      ])
+
+      expect(result.missing).toHaveLength(0)
+    })
+  })
+})

--- a/src/shared/dependency/dependency.service.ts
+++ b/src/shared/dependency/dependency.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common'
+
+import { ProcessService } from '@/shared/process'
+import type {
+  Dependency,
+  DependencyResult,
+  DependencyServiceCheck,
+  DependencyWarning,
+  MissingDependency
+} from './interfaces'
+
+@Injectable()
+export class DependencyService implements DependencyServiceCheck {
+  constructor(private readonly process: ProcessService) {}
+
+  which(command: string): string | null {
+    return this.process.which(command)
+  }
+
+  private compareVersions(installed: string | null, required: string): boolean {
+    if (!installed) return false
+
+    if (required.startsWith('>=')) {
+      const minVersion = required.slice(2).trim()
+      return this.satisfiesGte(installed, minVersion)
+    }
+    if (required.startsWith('^')) {
+      const major = required.slice(1).trim()
+      return installed.startsWith(`${major.split('.')[0]}.`)
+    }
+    if (required.startsWith('~')) {
+      const minVersion = required.slice(1).trim()
+      const [major, minor] = minVersion.split('.')
+      return installed.startsWith(`${major}.${minor}.`)
+    }
+    return installed === required
+  }
+
+  private satisfiesGte(installed: string, minVersion: string): boolean {
+    const [i1, i2, i3] = installed.split('.').map(Number)
+    const [m1, m2, m3] = minVersion.split('.').map(Number)
+
+    if (i1 > m1) return true
+    if (i1 < m1) return false
+    if (i2 > m2) return true
+    if (i2 < m2) return false
+    return i3 >= m3
+  }
+
+  async check(dependencies: Dependency[]): Promise<DependencyResult> {
+    const missing: MissingDependency[] = []
+    const warnings: DependencyWarning[] = []
+
+    for (const dep of dependencies) {
+      const command = dep.command || dep.name
+      const installedPath = this.process.which(command)
+
+      if (!installedPath) {
+        if (dep.isRequired !== false) {
+          missing.push({
+            name: dep.name,
+            requiredVersion: dep.version || null,
+            installedVersion: null,
+            installedPath: null,
+            isMet: false
+          })
+        }
+        continue
+      }
+
+      const installedVersion = await this.process.getVersion(command)
+      const isMet = dep.version ? this.compareVersions(installedVersion, dep.version) : true
+
+      if (!isMet) {
+        warnings.push({
+          name: dep.name,
+          installedVersion: installedVersion || null,
+          requiredVersion: dep.version || null,
+          installedPath
+        })
+      }
+    }
+
+    return { missing, warnings }
+  }
+}

--- a/src/shared/dependency/index.ts
+++ b/src/shared/dependency/index.ts
@@ -1,0 +1,9 @@
+export { DependencyModule } from './dependency.module'
+export { DependencyService } from './dependency.service'
+export type {
+  Dependency,
+  DependencyResult,
+  DependencyServiceCheck,
+  DependencyWarning,
+  MissingDependency
+} from './interfaces'

--- a/src/shared/dependency/interfaces/dependency.interface.ts
+++ b/src/shared/dependency/interfaces/dependency.interface.ts
@@ -1,0 +1,31 @@
+export interface Dependency {
+  name: string
+  version?: string
+  command?: string
+  isRequired?: boolean
+  description?: string
+}
+
+export interface MissingDependency {
+  name: string
+  requiredVersion: string | null
+  installedVersion: string | null
+  installedPath: string | null
+  isMet: boolean
+}
+
+export interface DependencyWarning {
+  name: string
+  installedVersion: string | null
+  requiredVersion: string | null
+  installedPath: string | null
+}
+
+export interface DependencyResult {
+  missing: MissingDependency[]
+  warnings: DependencyWarning[]
+}
+
+export interface DependencyServiceCheck {
+  check(dependencies: Dependency[]): Promise<DependencyResult>
+}

--- a/src/shared/dependency/interfaces/index.ts
+++ b/src/shared/dependency/interfaces/index.ts
@@ -1,0 +1,7 @@
+export type {
+  Dependency,
+  DependencyResult,
+  DependencyServiceCheck,
+  DependencyWarning,
+  MissingDependency
+} from './dependency.interface'

--- a/src/shared/process/process.service.spec.ts
+++ b/src/shared/process/process.service.spec.ts
@@ -65,4 +65,44 @@ describe('ProcessService', () => {
       expect(() => validator.validate('echo $PATH')).toThrow()
     })
   })
+
+  describe('which', () => {
+    it('should return path for installed command', () => {
+      const result = service.which('git')
+
+      expect(result).toBeTruthy()
+      expect(result).toContain('git')
+    })
+
+    it('should return null for non-existent command', () => {
+      const result = service.which('nonexistent-command-xyz-12345')
+
+      expect(result).toBeNull()
+    })
+
+    it('should throw on dangerous command name', () => {
+      expect(() => service.which('echo; rm -rf')).toThrow()
+    })
+  })
+
+  describe('getVersion', () => {
+    it('should return version for git', async () => {
+      const version = await service.getVersion('git')
+
+      expect(version).toMatch(/\d+\.\d+\.\d+/)
+    })
+
+    it('should return null for non-existent command', async () => {
+      const version = await service.getVersion('nonexistent-command-xyz-12345')
+
+      expect(version).toBeNull()
+    })
+
+    it('should use custom args', async () => {
+      const version = await service.getVersion('node', ['--version'])
+
+      expect(version).toBeTruthy()
+      expect(version).toMatch(/\d+/)
+    })
+  })
 })

--- a/src/shared/process/process.service.ts
+++ b/src/shared/process/process.service.ts
@@ -1,5 +1,13 @@
-import { type ChildProcess, exec as execCallback, execSync, spawn } from 'node:child_process'
+import {
+  type ChildProcess,
+  exec as execCallback,
+  execSync,
+  type SpawnOptions,
+  spawn
+} from 'node:child_process'
+import { platform } from 'node:os'
 import { promisify } from 'node:util'
+
 import { Injectable } from '@nestjs/common'
 
 import { ExitCodes } from '@/shared/exit-codes'
@@ -55,13 +63,49 @@ export class ProcessService implements Executor {
    * This is the safest method as it avoids shell interpretation
    * @param command - The executable to run
    * @param args - Array of arguments (will be properly escaped)
+   * @param options - Additional spawn options
    */
-  spawn(command: string, args: string[]): ChildProcess {
+  spawn(command: string, args: string[], options: SpawnOptions = {}): ChildProcess {
     this.validator.validateArgs(args)
     // No shell: true - arguments are passed directly to the process
     // This prevents shell injection attacks
     return spawn(command, args, {
-      stdio: 'inherit'
+      stdio: 'inherit',
+      ...options
     })
+  }
+
+  /**
+   * Find the full path of a command using which/where
+   * @param command - Command name to locate
+   * @returns Full path or null if not found
+   */
+  which(command: string): string | null {
+    this.validator.validate(command)
+    try {
+      const cmd = platform() === 'win32' ? 'where' : 'which'
+      const result = execSync(`${cmd} ${command}`, { encoding: 'utf-8' }).trim()
+      return result.split('\n')[0]
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Get version of an installed command
+   * @param command - Command name
+   * @param args - Version args (default: ['--version'])
+   */
+  async getVersion(command: string, args = ['--version']): Promise<string | null> {
+    this.validator.validateArgs(args)
+    try {
+      const result = await execAsync(`${command} ${args.join(' ')}`)
+      const output = (result.stdout || result.stderr).trim()
+      // Extract first semver-like pattern (e.g., 2.50.1, v2.50.1)
+      const match = output.match(/(\d+\.\d+\.\d+(?:\.\d+)?)/)
+      return match ? match[1] : null
+    } catch {
+      return null
+    }
   }
 }

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,12 +1,13 @@
 import { Global, Module } from '@nestjs/common'
 
 import { ConsoleModule } from './console'
+import { DependencyModule } from './dependency'
 import { FileHandlerModule } from './file-handler'
 import { ProcessModule } from './process'
 import { PromptModule } from './prompt'
 
 @Global()
 @Module({
-  imports: [ConsoleModule, FileHandlerModule, ProcessModule, PromptModule]
+  imports: [ConsoleModule, DependencyModule, FileHandlerModule, ProcessModule, PromptModule]
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary

- Adds `doctor` CLI command to check dependency health (git >=2.30, docker >=24.0)
- Implements `DependencyService` with semver version comparison (>=, ^, ~, exact)
- Adds global dependency check before CLI execution (skips for --help/--version)
- Removes unnecessary `@nestjs/platform-express` dependency from CLI app
- Uses `NestFactory.createApplicationContext()` for lightweight DI without HTTP server

## Changes

- `src/cli/commands/doctor.command.ts` - New doctor command with verbose mode (-v, --verbose)
- `src/shared/dependency/` - New dependency module with version checking logic
- `src/config/constants/dependencies.constants.ts` - Dependency definitions
- `src/main.ts` - Uses `createApplicationContext()` instead of `create()`
- `package.json` - Removed `@nestjs/platform-express`
- `biome.json` - Added overrides for dependency module

## Testing

- All 282 tests pass
- Coverage meets 80% thresholds (82.53% statements, 83.87% branches, 87.5% functions, 83.79% lines)
- Added test coverage for doctor command